### PR TITLE
Add basic OIDC setup for STAC API transaction extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,17 @@
 
 STAC Auth Proxy is a proxy API that mediates between the client and and some internally accessible STAC API in order to provide a flexible authentication mechanism.
 
-## Development
+## Installation
 
-```sh
+Set up connection to upstream STAC API and the OpenID Connect provider by setting the following environment variables:
+
+```bash
+export STAC_AUTH_PROXY_UPSTREAM_URL="https://some.url"
+export STAC_AUTH_PROXY_AUTH_PROVIDER="https://your-openid-connect-provider.com/.well-known/openid-configuration"
+```
+
+Install software:
+
+```bash
 uv run python -m stac_auth_proxy
 ```

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -6,119 +6,49 @@ authentication, authorization, and proxying of requests to some internal STAC AP
 """
 
 import os
-import httpx
-from fastapi import Depends, FastAPI, Request, Security
+from fastapi import Depends, FastAPI
 from fastapi.security import OpenIdConnect
+
+from .proxy import Proxy
+
 
 app = FastAPI()
 
 STAC_API_URL = os.environ.get(
     "STAC_AUTH_PROXY_UPSTREAM_API",
-    "https://earth-search.aws.element84.com/v1"
+    "https://earth-search.aws.element84.com/v1",
 )
 
 AUTH_PROVIDER_URL = os.environ.get(
     "STAC_AUTH_PROXY_AUTH_PROVIDER",
-    "https://your-openid-connect-provider.com/.well-known/openid-configuration"
+    "https://your-openid-connect-provider.com/.well-known/openid-configuration",
 )
 
 open_id_connect_scheme = OpenIdConnect(
-    openIdConnectUrl=AUTH_PROVIDER_URL
+    openIdConnectUrl=AUTH_PROVIDER_URL,
     scheme_name="OpenID Connect",
     description="OpenID Connect authentication for STAC API access",
 )
 
-@app.post("/search")
-async def search_stac_api(request: Request):
-    search_params = await request.json()
-    async with httpx.AsyncClient() as client:
-        response = await client.post(f"{STAC_API_URL}/search", json=search_params)
-    return response.json()
+proxy = Proxy(upstream=STAC_API_URL)
 
+# Transactions Extension Endpoins
+for path, methods in {
+    # https://github.com/stac-api-extensions/collection-transaction/blob/v1.0.0-beta.1/README.md#methods
+    "/collections": ["POST"],
+    "/collections/{collection_id}": ["PUT", "PATCH", "DELETE"],
+    # https://github.com/stac-api-extensions/transaction/blob/v1.0.0-rc.3/README.md#methods
+    "/collections/{collection_id}/items": ["POST"],
+    "/collections/{collection_id}/items/{item_id}": ["PUT", "PATCH", "DELETE"],
+    # https://stac-utils.github.io/stac-fastapi/api/stac_fastapi/extensions/third_party/bulk_transactions/#bulktransactionextension
+    "/collections/{collection_id}/bulk_items": ["POST"],
+}.items():
+    app.add_api_route(
+        path,
+        proxy.passthrough,
+        methods=methods,
+        dependencies=[Depends(open_id_connect_scheme)],
+    )
 
-@app.get("/collections")
-async def get_collections():
-    async with httpx.AsyncClient() as client:
-        response = await client.get(f"{STAC_API_URL}/collections")
-    return response.json()
-
-
-@app.get("/collections/{collection_id}")
-async def get_collection_by_id(collection_id: str):
-    async with httpx.AsyncClient() as client:
-        response = await client.get(f"{STAC_API_URL}/collections/{collection_id}")
-    return response.json()
-
-
-@app.get("/items")
-async def get_items():
-    async with httpx.AsyncClient() as client:
-        response = await client.get(f"{STAC_API_URL}/items")
-    return response.json()
-
-
-@app.get("/items/{item_id}")
-async def get_item_by_id(item_id: str):
-    async with httpx.AsyncClient() as client:
-        response = await client.get(f"{STAC_API_URL}/items/{item_id}")
-    return response.json()
-
-
-@app.get("/assets/{item_id}")
-async def get_assets(item_id: str):
-    async with httpx.AsyncClient() as client:
-        response = await client.get(f"{STAC_API_URL}/items/{item_id}/assets")
-    return response.json()
-
-
-@app.post("/collections/{collection_id}/items")
-async def add_item_to_collection(
-    collection_id: str, request: Request, token: str = Depends(open_id_connect_scheme)
-):
-    item = await request.json()
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            f"{STAC_API_URL}/collections/{collection_id}/items", json=item
-        )
-    return response.json()
-
-
-@app.put("/collections/{collection_id}/items/{item_id}")
-async def replace_item_in_collection(
-    collection_id: str,
-    item_id: str,
-    request: Request,
-    token: str = Depends(open_id_connect_scheme)
-):
-    item = await request.json()
-    async with httpx.AsyncClient() as client:
-        response = await client.put(
-            f"{STAC_API_URL}/collections/{collection_id}/items/{item_id}", json=item
-        )
-    return response.json()
-
-
-@app.patch("/collections/{collection_id}/items/{item_id}")
-async def update_item_in_collection(
-    collection_id: str,
-    item_id: str,
-    request: Request,
-    token: str = Depends(open_id_connect_scheme)
-):
-    item = await request.json()
-    async with httpx.AsyncClient() as client:
-        response = await client.patch(
-            f"{STAC_API_URL}/collections/{collection_id}/items/{item_id}", json=item
-        )
-    return response.json()
-
-
-@app.delete("/collections/{collection_id}/items/{item_id}")
-async def delete_item_from_collection(
-    collection_id: str, item_id: str, token: str = Depends(open_id_connect_scheme)
-):
-    async with httpx.AsyncClient() as client:
-        response = await client.delete(
-            f"{STAC_API_URL}/collections/{collection_id}/items/{item_id}"
-        )
-    return response.json()
+# Catchall proxy
+app.add_route("/{path:path}", proxy.passthrough)

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -5,6 +5,120 @@ authentication, authorization, and proxying of requests to some internal STAC AP
 
 """
 
-from fastapi import FastAPI
+import os
+import httpx
+from fastapi import Depends, FastAPI, Request, Security
+from fastapi.security import OpenIdConnect
 
 app = FastAPI()
+
+STAC_API_URL = os.environ.get(
+    "STAC_AUTH_PROXY_UPSTREAM_API",
+    "https://earth-search.aws.element84.com/v1"
+)
+
+AUTH_PROVIDER_URL = os.environ.get(
+    "STAC_AUTH_PROXY_AUTH_PROVIDER",
+    "https://your-openid-connect-provider.com/.well-known/openid-configuration"
+)
+
+open_id_connect_scheme = OpenIdConnect(
+    openIdConnectUrl=AUTH_PROVIDER_URL
+    scheme_name="OpenID Connect",
+    description="OpenID Connect authentication for STAC API access",
+)
+
+@app.post("/search")
+async def search_stac_api(request: Request):
+    search_params = await request.json()
+    async with httpx.AsyncClient() as client:
+        response = await client.post(f"{STAC_API_URL}/search", json=search_params)
+    return response.json()
+
+
+@app.get("/collections")
+async def get_collections():
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{STAC_API_URL}/collections")
+    return response.json()
+
+
+@app.get("/collections/{collection_id}")
+async def get_collection_by_id(collection_id: str):
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{STAC_API_URL}/collections/{collection_id}")
+    return response.json()
+
+
+@app.get("/items")
+async def get_items():
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{STAC_API_URL}/items")
+    return response.json()
+
+
+@app.get("/items/{item_id}")
+async def get_item_by_id(item_id: str):
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{STAC_API_URL}/items/{item_id}")
+    return response.json()
+
+
+@app.get("/assets/{item_id}")
+async def get_assets(item_id: str):
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{STAC_API_URL}/items/{item_id}/assets")
+    return response.json()
+
+
+@app.post("/collections/{collection_id}/items")
+async def add_item_to_collection(
+    collection_id: str, request: Request, token: str = Depends(open_id_connect_scheme)
+):
+    item = await request.json()
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{STAC_API_URL}/collections/{collection_id}/items", json=item
+        )
+    return response.json()
+
+
+@app.put("/collections/{collection_id}/items/{item_id}")
+async def replace_item_in_collection(
+    collection_id: str,
+    item_id: str,
+    request: Request,
+    token: str = Depends(open_id_connect_scheme)
+):
+    item = await request.json()
+    async with httpx.AsyncClient() as client:
+        response = await client.put(
+            f"{STAC_API_URL}/collections/{collection_id}/items/{item_id}", json=item
+        )
+    return response.json()
+
+
+@app.patch("/collections/{collection_id}/items/{item_id}")
+async def update_item_in_collection(
+    collection_id: str,
+    item_id: str,
+    request: Request,
+    token: str = Depends(open_id_connect_scheme)
+):
+    item = await request.json()
+    async with httpx.AsyncClient() as client:
+        response = await client.patch(
+            f"{STAC_API_URL}/collections/{collection_id}/items/{item_id}", json=item
+        )
+    return response.json()
+
+
+@app.delete("/collections/{collection_id}/items/{item_id}")
+async def delete_item_from_collection(
+    collection_id: str, item_id: str, token: str = Depends(open_id_connect_scheme)
+):
+    async with httpx.AsyncClient() as client:
+        response = await client.delete(
+            f"{STAC_API_URL}/collections/{collection_id}/items/{item_id}"
+        )
+    return response.json()

--- a/src/stac_auth_proxy/proxy.py
+++ b/src/stac_auth_proxy/proxy.py
@@ -1,0 +1,55 @@
+import logging
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from fastapi import Request
+
+from starlette.datastructures import MutableHeaders
+from starlette.responses import StreamingResponse
+from starlette.background import BackgroundTask
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Proxy:
+    upstream: str
+    client: httpx.AsyncClient = None
+
+    def __post_init__(self):
+        self.client = self.client or httpx.AsyncClient(
+            base_url=self.upstream,
+            timeout=httpx.Timeout(timeout=15.0),
+        )
+
+    async def passthrough(self, request: Request):
+        """Transparently proxy a request to the upstream STAC API."""
+
+        headers = MutableHeaders(request.headers)
+        headers["Host"] = urlparse(self.upstream).hostname
+
+        # https://github.com/fastapi/fastapi/discussions/7382#discussioncomment-5136466
+        rp_req = self.client.build_request(
+            request.method,
+            url=httpx.URL(
+                path=request.url.path,
+                query=request.url.query.encode("utf-8"),
+            ),
+            headers=headers,
+            content=request.stream(),
+        )
+        logger.debug(f"Proxying request to {rp_req.url}")
+
+        rp_resp = await self.client.send(rp_req, stream=True)
+        logger.debug(
+            f"Received response status {rp_resp.status_code!r} from {rp_req.url}"
+        )
+
+        return StreamingResponse(
+            rp_resp.aiter_raw(),
+            status_code=rp_resp.status_code,
+            headers=rp_resp.headers,
+            background=BackgroundTask(rp_resp.aclose),
+        )


### PR DESCRIPTION
This PR introduces an initial use case. Everything here is highly specific and will need to be made configurable and extended in future PRs.

For now:

* Rely on OpenID Connect
* Keep regular STAC API endpoints public
* Protect STAC API Transaction extension endpoints
