### PR TITLE
Refactor proxy

### DIFF
--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -32,9 +32,16 @@ open_id_connect_scheme = OpenIdConnect(
 
 proxy = Proxy(upstream=STAC_API_URL)
 
+# Transactions Extension Endpoins
 for path, methods in {
+    # https://github.com/stac-api-extensions/collection-transaction/blob/v1.0.0-beta.1/README.md#methods
+    "/collections": ["POST"],
+    "/collections/{collection_id}": ["PUT", "PATCH", "DELETE"],
+    # https://github.com/stac-api-extensions/transaction/blob/v1.0.0-rc.3/README.md#methods
     "/collections/{collection_id}/items": ["POST"],
     "/collections/{collection_id}/items/{item_id}": ["PUT", "PATCH", "DELETE"],
+    # https://stac-utils.github.io/stac-fastapi/api/stac_fastapi/extensions/third_party/bulk_transactions/#bulktransactionextension
+    "/collections/{collection_id}/bulk_items": ["POST"],
 }.items():
     app.add_api_route(
         path,
@@ -42,5 +49,6 @@ for path, methods in {
         methods=methods,
         dependencies=[Depends(open_id_connect_scheme)],
     )
+
 # Catchall proxy
 app.add_route("/{path:path}", proxy.passthrough)

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -15,7 +15,8 @@ from .proxy import Proxy
 app = FastAPI()
 
 STAC_API_URL = os.environ.get(
-    "STAC_AUTH_PROXY_UPSTREAM_API", "https://earth-search.aws.element84.com/v1"
+    "STAC_AUTH_PROXY_UPSTREAM_API",
+    "https://earth-search.aws.element84.com/v1",
 )
 
 AUTH_PROVIDER_URL = os.environ.get(

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -37,9 +37,9 @@ for path, methods in {
 }.items():
     app.add_api_route(
         path,
-        proxy.route,
+        proxy.passthrough,
         methods=methods,
         dependencies=[Depends(open_id_connect_scheme)],
     )
 # Catchall proxy
-app.add_route("/{path:path}", proxy.route)
+app.add_route("/{path:path}", proxy.passthrough)

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -6,119 +6,40 @@ authentication, authorization, and proxying of requests to some internal STAC AP
 """
 
 import os
-import httpx
-from fastapi import Depends, FastAPI, Request, Security
+from fastapi import Depends, FastAPI
 from fastapi.security import OpenIdConnect
+
+from .proxy import Proxy
+
 
 app = FastAPI()
 
 STAC_API_URL = os.environ.get(
-    "STAC_AUTH_PROXY_UPSTREAM_API",
-    "https://earth-search.aws.element84.com/v1"
+    "STAC_AUTH_PROXY_UPSTREAM_API", "https://earth-search.aws.element84.com/v1"
 )
 
 AUTH_PROVIDER_URL = os.environ.get(
     "STAC_AUTH_PROXY_AUTH_PROVIDER",
-    "https://your-openid-connect-provider.com/.well-known/openid-configuration"
+    "https://your-openid-connect-provider.com/.well-known/openid-configuration",
 )
 
 open_id_connect_scheme = OpenIdConnect(
-    openIdConnectUrl=AUTH_PROVIDER_URL
+    openIdConnectUrl=AUTH_PROVIDER_URL,
     scheme_name="OpenID Connect",
     description="OpenID Connect authentication for STAC API access",
 )
 
-@app.post("/search")
-async def search_stac_api(request: Request):
-    search_params = await request.json()
-    async with httpx.AsyncClient() as client:
-        response = await client.post(f"{STAC_API_URL}/search", json=search_params)
-    return response.json()
+proxy = Proxy(upstream=STAC_API_URL)
 
-
-@app.get("/collections")
-async def get_collections():
-    async with httpx.AsyncClient() as client:
-        response = await client.get(f"{STAC_API_URL}/collections")
-    return response.json()
-
-
-@app.get("/collections/{collection_id}")
-async def get_collection_by_id(collection_id: str):
-    async with httpx.AsyncClient() as client:
-        response = await client.get(f"{STAC_API_URL}/collections/{collection_id}")
-    return response.json()
-
-
-@app.get("/items")
-async def get_items():
-    async with httpx.AsyncClient() as client:
-        response = await client.get(f"{STAC_API_URL}/items")
-    return response.json()
-
-
-@app.get("/items/{item_id}")
-async def get_item_by_id(item_id: str):
-    async with httpx.AsyncClient() as client:
-        response = await client.get(f"{STAC_API_URL}/items/{item_id}")
-    return response.json()
-
-
-@app.get("/assets/{item_id}")
-async def get_assets(item_id: str):
-    async with httpx.AsyncClient() as client:
-        response = await client.get(f"{STAC_API_URL}/items/{item_id}/assets")
-    return response.json()
-
-
-@app.post("/collections/{collection_id}/items")
-async def add_item_to_collection(
-    collection_id: str, request: Request, token: str = Depends(open_id_connect_scheme)
-):
-    item = await request.json()
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            f"{STAC_API_URL}/collections/{collection_id}/items", json=item
-        )
-    return response.json()
-
-
-@app.put("/collections/{collection_id}/items/{item_id}")
-async def replace_item_in_collection(
-    collection_id: str,
-    item_id: str,
-    request: Request,
-    token: str = Depends(open_id_connect_scheme)
-):
-    item = await request.json()
-    async with httpx.AsyncClient() as client:
-        response = await client.put(
-            f"{STAC_API_URL}/collections/{collection_id}/items/{item_id}", json=item
-        )
-    return response.json()
-
-
-@app.patch("/collections/{collection_id}/items/{item_id}")
-async def update_item_in_collection(
-    collection_id: str,
-    item_id: str,
-    request: Request,
-    token: str = Depends(open_id_connect_scheme)
-):
-    item = await request.json()
-    async with httpx.AsyncClient() as client:
-        response = await client.patch(
-            f"{STAC_API_URL}/collections/{collection_id}/items/{item_id}", json=item
-        )
-    return response.json()
-
-
-@app.delete("/collections/{collection_id}/items/{item_id}")
-async def delete_item_from_collection(
-    collection_id: str, item_id: str, token: str = Depends(open_id_connect_scheme)
-):
-    async with httpx.AsyncClient() as client:
-        response = await client.delete(
-            f"{STAC_API_URL}/collections/{collection_id}/items/{item_id}"
-        )
-    return response.json()
+for path, methods in {
+    "/collections/{collection_id}/items": ["POST"],
+    "/collections/{collection_id}/items/{item_id}": ["PUT", "PATCH", "DELETE"],
+}.items():
+    app.add_api_route(
+        path,
+        proxy.route,
+        methods=methods,
+        dependencies=[Depends(open_id_connect_scheme)],
+    )
+# Catchall proxy
+app.add_route("/{path:path}", proxy.route)

--- a/src/stac_auth_proxy/proxy.py
+++ b/src/stac_auth_proxy/proxy.py
@@ -25,13 +25,17 @@ class Proxy:
         )
 
     async def passthrough(self, request: Request):
+        """Transparently proxy a request to the upstream STAC API."""
+
         headers = MutableHeaders(request.headers)
         headers["Host"] = urlparse(self.upstream).hostname
 
+        # https://github.com/fastapi/fastapi/discussions/7382#discussioncomment-5136466
         rp_req = self.client.build_request(
             request.method,
             url=httpx.URL(
-                path=request.url.path, query=request.url.query.encode("utf-8")
+                path=request.url.path,
+                query=request.url.query.encode("utf-8"),
             ),
             headers=headers,
             content=request.stream(),

--- a/src/stac_auth_proxy/proxy.py
+++ b/src/stac_auth_proxy/proxy.py
@@ -24,7 +24,7 @@ class Proxy:
             timeout=httpx.Timeout(timeout=15.0),
         )
 
-    async def route(self, request: Request):
+    async def passthrough(self, request: Request):
         headers = MutableHeaders(request.headers)
         headers["Host"] = urlparse(self.upstream).hostname
 

--- a/src/stac_auth_proxy/proxy.py
+++ b/src/stac_auth_proxy/proxy.py
@@ -1,0 +1,51 @@
+import logging
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from fastapi import Request
+
+from starlette.datastructures import MutableHeaders
+from starlette.responses import StreamingResponse
+from starlette.background import BackgroundTask
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Proxy:
+    upstream: str
+    client: httpx.AsyncClient = None
+
+    def __post_init__(self):
+        self.client = self.client or httpx.AsyncClient(
+            base_url=self.upstream,
+            timeout=httpx.Timeout(timeout=15.0),
+        )
+
+    async def route(self, request: Request):
+        headers = MutableHeaders(request.headers)
+        headers["Host"] = urlparse(self.upstream).hostname
+
+        rp_req = self.client.build_request(
+            request.method,
+            url=httpx.URL(
+                path=request.url.path, query=request.url.query.encode("utf-8")
+            ),
+            headers=headers,
+            content=request.stream(),
+        )
+        logger.debug(f"Proxying request to {rp_req.url}")
+
+        rp_resp = await self.client.send(rp_req, stream=True)
+        logger.debug(
+            f"Received response status {rp_resp.status_code!r} from {rp_req.url}"
+        )
+
+        return StreamingResponse(
+            rp_resp.aiter_raw(),
+            status_code=rp_resp.status_code,
+            headers=rp_resp.headers,
+            background=BackgroundTask(rp_resp.aclose),
+        )


### PR DESCRIPTION
In this PR, we move the logic around proxying requests to class (`stac_auth_proxy.proxy:Proxy`) which currently only passes the requests to the upstream proxy.

Additionally, to avoid the chore of defining each route individually, we only define routes by those that require the auth dependency and then a generic catch-all route for everything else.