### PR TITLE
fix: prevent down oidc from interfering with lifespan

### DIFF
--- a/tests/test_filters_jinja2.py
+++ b/tests/test_filters_jinja2.py
@@ -18,7 +18,7 @@ FILTER_EXPR_CASES = [
         id="simple_not_templated",
     ),
     pytest.param(
-        "{{ '(properties.private = false)' if user is none else true }}",
+        "{{ '(properties.private = false)' if payload is none else true }}",
         "true",
         "(properties.private = false)",
         id="simple_templated",
@@ -30,7 +30,7 @@ FILTER_EXPR_CASES = [
         id="complex_not_templated",
     ),
     pytest.param(
-        """{{ '{"op": "=", "args": [{"property": "private"}, true]}' if user is none else true }}""",
+        """{{ '{"op": "=", "args": [{"property": "private"}, true]}' if payload is none else true }}""",
         "true",
         """{"op": "=", "args": [{"property": "private"}, true]}""",
         id="complex_templated",


### PR DESCRIPTION
When using lifespan handlers, errors thrown when initializing middleware can interfere with lifespan handling.

This PR:

1. Initializes the JWKS client in a lazy manner
2. Reworks the default state key for token payload from `user` to `payload`
3. Accelerates test speed by persisting fixtures across tests