### PR TITLE
feat: configurable root_path

### DIFF
--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -21,6 +21,7 @@ from .middleware import (
     BuildCql2FilterMiddleware,
     EnforceAuthMiddleware,
     OpenApiMiddleware,
+    RemoveRootPathMiddleware,
 )
 from .utils.lifespan import check_conformance, check_server_health
 
@@ -75,6 +76,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     #
     # Handlers (place catch-all proxy handler last)
     #
+
     if settings.healthz_prefix:
         app.include_router(
             HealthzHandler(upstream_url=str(settings.upstream_url)).router,
@@ -90,6 +92,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     #
     # Middleware (order is important, last added = first to run)
     #
+
     if settings.enable_authentication_extension:
         app.add_middleware(
             AuthenticationExtensionMiddleware,
@@ -134,5 +137,11 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
         default_public=settings.default_public,
         oidc_config_url=settings.oidc_discovery_internal_url,
     )
+
+    if settings.root_path:
+        app.add_middleware(
+            RemoveRootPathMiddleware,
+            base_path=settings.root_path,
+        )
 
     return app

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -18,10 +18,11 @@ from .middleware import (
     AddProcessTimeHeaderMiddleware,
     ApplyCql2FilterMiddleware,
     AuthenticationExtensionMiddleware,
-    BasePathMiddleware,
     BuildCql2FilterMiddleware,
     EnforceAuthMiddleware,
     OpenApiMiddleware,
+    ProcessLinksMiddleware,
+    RemoveRootPathMiddleware,
 )
 from .utils.lifespan import check_conformance, check_server_health
 
@@ -133,9 +134,16 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
         oidc_config_url=settings.oidc_discovery_internal_url,
     )
 
+    if settings.root_path or settings.upstream_url.path != "/":
+        app.add_middleware(
+            ProcessLinksMiddleware,
+            upstream_url=str(settings.upstream_url),
+            base_path=settings.root_path,
+        )
+
     if settings.root_path:
         app.add_middleware(
-            BasePathMiddleware,
+            RemoveRootPathMiddleware,
             base_path=settings.root_path,
         )
 

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -67,7 +67,10 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     app = FastAPI(
         openapi_url=None,  # Disable OpenAPI schema endpoint, we want to serve upstream's schema
         lifespan=lifespan,
+        root_path=settings.root_path,
     )
+    if app.root_path:
+        logger.debug("Mounted app at %s", app.root_path)
 
     #
     # Handlers (place catch-all proxy handler last)

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -18,10 +18,10 @@ from .middleware import (
     AddProcessTimeHeaderMiddleware,
     ApplyCql2FilterMiddleware,
     AuthenticationExtensionMiddleware,
+    BasePathMiddleware,
     BuildCql2FilterMiddleware,
     EnforceAuthMiddleware,
     OpenApiMiddleware,
-    RemoveRootPathMiddleware,
 )
 from .utils.lifespan import check_conformance, check_server_health
 
@@ -121,11 +121,6 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             items_filter=settings.items_filter(),
         )
 
-    if settings.enable_compression:
-        app.add_middleware(
-            CompressionMiddleware,
-        )
-
     app.add_middleware(
         AddProcessTimeHeaderMiddleware,
     )
@@ -140,8 +135,13 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
 
     if settings.root_path:
         app.add_middleware(
-            RemoveRootPathMiddleware,
+            BasePathMiddleware,
             base_path=settings.root_path,
+        )
+
+    if settings.enable_compression:
+        app.add_middleware(
+            CompressionMiddleware,
         )
 
     return app

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -138,13 +138,13 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
         app.add_middleware(
             ProcessLinksMiddleware,
             upstream_url=str(settings.upstream_url),
-            base_path=settings.root_path,
+            root_path=settings.root_path,
         )
 
     if settings.root_path:
         app.add_middleware(
             RemoveRootPathMiddleware,
-            base_path=settings.root_path,
+            root_path=settings.root_path,
         )
 
     if settings.enable_compression:

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -106,6 +106,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             public_endpoints=settings.public_endpoints,
             private_endpoints=settings.private_endpoints,
             default_public=settings.default_public,
+            root_path=settings.root_path,
         )
 
     if settings.items_filter:

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
     oidc_discovery_url: HttpUrl
     oidc_discovery_internal_url: HttpUrl
 
+    root_path: str = ""
     wait_for_upstream: bool = True
     check_conformance: bool = True
     enable_compression: bool = True

--- a/src/stac_auth_proxy/middleware/BasePathMiddleware.py
+++ b/src/stac_auth_proxy/middleware/BasePathMiddleware.py
@@ -1,0 +1,33 @@
+"""Middleware to remove BASE_PATH from incoming requests."""
+
+from dataclasses import dataclass
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+@dataclass
+class RemoveRootPathMiddleware:
+    """
+    Middleware to remove BASE_PATH from incoming requests.
+
+    IMPORTANT: This middleware must be the first middleware in the chain (ie last in the
+    order of declaration) so that it trims the base_path from the request path before
+    other middleware review the request.
+    """
+
+    app: ASGIApp
+    base_path: str
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Remove BASE_PATH from the request path if it exists."""
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        path = scope["path"]
+
+        # Remove base_path if it exists at the start of the path
+        if path.startswith(self.base_path):
+            scope["raw_path"] = scope["path"].encode()
+            scope["path"] = path[len(self.base_path) :] or "/"
+
+        return await self.app(scope, receive, send)

--- a/src/stac_auth_proxy/middleware/BasePathMiddleware.py
+++ b/src/stac_auth_proxy/middleware/BasePathMiddleware.py
@@ -1,14 +1,25 @@
-"""Middleware to remove BASE_PATH from incoming requests."""
+"""Middleware to remove BASE_PATH from incoming requests and update links in responses."""
 
+import logging
+import re
 from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse, urlunparse
 
+from starlette.datastructures import Headers
+from starlette.requests import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
+
+from ..utils.middleware import JsonResponseMiddleware
+from ..utils.stac import get_links
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
-class RemoveRootPathMiddleware:
+class BasePathMiddleware(JsonResponseMiddleware):
     """
-    Middleware to remove BASE_PATH from incoming requests.
+    Middleware to handle the base path of the request and update links in responses.
 
     IMPORTANT: This middleware must be the first middleware in the chain (ie last in the
     order of declaration) so that it trims the base_path from the request path before
@@ -17,6 +28,9 @@ class RemoveRootPathMiddleware:
 
     app: ASGIApp
     base_path: str
+    transform_links: bool = True
+
+    json_content_type_expr: str = r"application/(geo\+)?json"
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Remove BASE_PATH from the request path if it exists."""
@@ -30,4 +44,36 @@ class RemoveRootPathMiddleware:
             scope["raw_path"] = scope["path"].encode()
             scope["path"] = path[len(self.base_path) :] or "/"
 
-        return await self.app(scope, receive, send)
+        return await super().__call__(scope, receive, send)
+
+    def should_transform_response(self, request: Request, scope: Scope) -> bool:
+        """Only transform responses with JSON content type."""
+        return bool(
+            re.match(
+                self.json_content_type_expr,
+                Headers(scope=scope).get("content-type", ""),
+            )
+        )
+
+    def transform_json(self, data: dict[str, Any], request: Request) -> dict[str, Any]:
+        """Update links in the response to include base_path."""
+        for link in get_links(data):
+            href = link.get("href")
+            if not href:
+                continue
+
+            try:
+                parsed_link = urlparse(href)
+
+                # Ignore links that are not for this proxy
+                if parsed_link.netloc != request.headers.get("host"):
+                    continue
+
+                parsed_link = parsed_link._replace(
+                    path=f"{self.base_path}{parsed_link.path}"
+                )
+                link["href"] = urlunparse(parsed_link)
+            except Exception as e:
+                logger.warning("Failed to parse link href %s: %s", href, str(e))
+
+        return data

--- a/src/stac_auth_proxy/middleware/ProcessLinksMiddleware.py
+++ b/src/stac_auth_proxy/middleware/ProcessLinksMiddleware.py
@@ -39,7 +39,7 @@ class ProcessLinksMiddleware(JsonResponseMiddleware):
         )
 
     def transform_json(self, data: dict[str, Any], request: Request) -> dict[str, Any]:
-        """Update links in the response to include base_path."""
+        """Update links in the response to include root_path."""
         for link in get_links(data):
             href = link.get("href")
             if not href:

--- a/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
+++ b/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
@@ -1,0 +1,40 @@
+"""Middleware to remove BASE_PATH from incoming requests and update links in responses."""
+
+import logging
+from dataclasses import dataclass
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RemoveRootPathMiddleware:
+    """
+    Middleware to remove the base path of the request before it is sent to the upstream
+    server.
+
+    IMPORTANT: This middleware must be place early in the middleware chain (ie late in the
+    order of declaration) so that it trims the base_path from the request path before any
+    middleware that may need to use the request path (e.g. EnforceAuthMiddleware).
+    """
+
+    app: ASGIApp
+    base_path: str
+    transform_links: bool = True
+
+    json_content_type_expr: str = r"application/(geo\+)?json"
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Remove BASE_PATH from the request path if it exists."""
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        path = scope["path"]
+
+        # Remove base_path if it exists at the start of the path
+        if path.startswith(self.base_path):
+            scope["raw_path"] = scope["path"].encode()
+            scope["path"] = path[len(self.base_path) :] or "/"
+
+        return await self.app(scope, receive, send)

--- a/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
+++ b/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
@@ -33,6 +33,7 @@ class RemoveRootPathMiddleware:
         # If root_path is set and path doesn't start with it, return 404
         if self.root_path and not path.startswith(self.root_path):
             response = Response("Not Found", status_code=404)
+            logger.error(f"Root path {self.root_path} not found in path {path}")
             await response(scope, receive, send)
             return
 

--- a/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
+++ b/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
@@ -1,4 +1,4 @@
-"""Middleware to remove BASE_PATH from incoming requests and update links in responses."""
+"""Middleware to remove ROOT_PATH from incoming requests and update links in responses."""
 
 import logging
 from dataclasses import dataclass
@@ -15,26 +15,26 @@ class RemoveRootPathMiddleware:
     server.
 
     IMPORTANT: This middleware must be placed early in the middleware chain (ie late in
-    the order of declaration) so that it trims the base_path from the request path before
+    the order of declaration) so that it trims the root_path from the request path before
     any middleware that may need to use the request path (e.g. EnforceAuthMiddleware).
     """
 
     app: ASGIApp
-    base_path: str
+    root_path: str
     transform_links: bool = True
 
     json_content_type_expr: str = r"application/(geo\+)?json"
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        """Remove BASE_PATH from the request path if it exists."""
+        """Remove ROOT_PATH from the request path if it exists."""
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
         path = scope["path"]
 
-        # Remove base_path if it exists at the start of the path
-        if path.startswith(self.base_path):
+        # Remove root_path if it exists at the start of the path
+        if path.startswith(self.root_path):
             scope["raw_path"] = scope["path"].encode()
-            scope["path"] = path[len(self.base_path) :] or "/"
+            scope["path"] = path[len(self.root_path) :] or "/"
 
         return await self.app(scope, receive, send)

--- a/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
+++ b/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class RemoveRootPathMiddleware:
     """
-    Middleware to remove the base path of the request before it is sent to the upstream
+    Middleware to remove the root path of the request before it is sent to the upstream
     server.
 
     IMPORTANT: This middleware must be placed early in the middleware chain (ie late in

--- a/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
+++ b/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
@@ -28,18 +28,18 @@ class RemoveRootPathMiddleware:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        path = scope["path"]
-
         # If root_path is set and path doesn't start with it, return 404
-        if self.root_path and not path.startswith(self.root_path):
+        if self.root_path and not scope["path"].startswith(self.root_path):
             response = Response("Not Found", status_code=404)
-            logger.error(f"Root path {self.root_path} not found in path {path}")
+            logger.error(
+                f"Root path {self.root_path!r} not found in path {scope['path']!r}"
+            )
             await response(scope, receive, send)
             return
 
         # Remove root_path if it exists at the start of the path
-        if path.startswith(self.root_path):
+        if scope["path"].startswith(self.root_path):
             scope["raw_path"] = scope["path"].encode()
-            scope["path"] = path[len(self.root_path) :] or "/"
+            scope["path"] = scope["path"][len(self.root_path) :] or "/"
 
         return await self.app(scope, receive, send)

--- a/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
+++ b/src/stac_auth_proxy/middleware/RemoveRootPathMiddleware.py
@@ -14,9 +14,9 @@ class RemoveRootPathMiddleware:
     Middleware to remove the base path of the request before it is sent to the upstream
     server.
 
-    IMPORTANT: This middleware must be place early in the middleware chain (ie late in the
-    order of declaration) so that it trims the base_path from the request path before any
-    middleware that may need to use the request path (e.g. EnforceAuthMiddleware).
+    IMPORTANT: This middleware must be placed early in the middleware chain (ie late in
+    the order of declaration) so that it trims the base_path from the request path before
+    any middleware that may need to use the request path (e.g. EnforceAuthMiddleware).
     """
 
     app: ASGIApp

--- a/src/stac_auth_proxy/middleware/UpdateOpenApiMiddleware.py
+++ b/src/stac_auth_proxy/middleware/UpdateOpenApiMiddleware.py
@@ -47,7 +47,7 @@ class OpenApiMiddleware(JsonResponseMiddleware):
 
     def transform_json(self, data: dict[str, Any], request: Request) -> dict[str, Any]:
         """Augment the OpenAPI spec with auth information."""
-        # Add servers field with base path if root_path is set
+        # Add servers field with root path if root_path is set
         if self.root_path:
             data["servers"] = [{"url": self.root_path}]
 

--- a/src/stac_auth_proxy/middleware/UpdateOpenApiMiddleware.py
+++ b/src/stac_auth_proxy/middleware/UpdateOpenApiMiddleware.py
@@ -23,6 +23,7 @@ class OpenApiMiddleware(JsonResponseMiddleware):
     private_endpoints: EndpointMethods
     public_endpoints: EndpointMethods
     default_public: bool
+    root_path: str = ""
     oidc_auth_scheme_name: str = "oidcAuth"
 
     json_content_type_expr: str = r"application/(vnd\.oai\.openapi\+json?|json)"
@@ -45,12 +46,19 @@ class OpenApiMiddleware(JsonResponseMiddleware):
 
     def transform_json(self, data: dict[str, Any], request: Request) -> dict[str, Any]:
         """Augment the OpenAPI spec with auth information."""
+        # Add servers field with base path if root_path is set
+        if self.root_path:
+            data["servers"] = [{"url": self.root_path}]
+
+        # Add security scheme
         components = data.setdefault("components", {})
         securitySchemes = components.setdefault("securitySchemes", {})
         securitySchemes[self.oidc_auth_scheme_name] = {
             "type": "openIdConnect",
             "openIdConnectUrl": self.oidc_config_url,
         }
+
+        # Add security to private endpoints
         for path, method_config in data["paths"].items():
             for method, config in method_config.items():
                 match = find_match(

--- a/src/stac_auth_proxy/middleware/__init__.py
+++ b/src/stac_auth_proxy/middleware/__init__.py
@@ -3,6 +3,7 @@
 from .AddProcessTimeHeaderMiddleware import AddProcessTimeHeaderMiddleware
 from .ApplyCql2FilterMiddleware import ApplyCql2FilterMiddleware
 from .AuthenticationExtensionMiddleware import AuthenticationExtensionMiddleware
+from .BasePathMiddleware import RemoveRootPathMiddleware
 from .BuildCql2FilterMiddleware import BuildCql2FilterMiddleware
 from .EnforceAuthMiddleware import EnforceAuthMiddleware
 from .UpdateOpenApiMiddleware import OpenApiMiddleware
@@ -11,6 +12,7 @@ __all__ = [
     "AddProcessTimeHeaderMiddleware",
     "ApplyCql2FilterMiddleware",
     "AuthenticationExtensionMiddleware",
+    "RemoveRootPathMiddleware",
     "BuildCql2FilterMiddleware",
     "EnforceAuthMiddleware",
     "OpenApiMiddleware",

--- a/src/stac_auth_proxy/middleware/__init__.py
+++ b/src/stac_auth_proxy/middleware/__init__.py
@@ -3,17 +3,19 @@
 from .AddProcessTimeHeaderMiddleware import AddProcessTimeHeaderMiddleware
 from .ApplyCql2FilterMiddleware import ApplyCql2FilterMiddleware
 from .AuthenticationExtensionMiddleware import AuthenticationExtensionMiddleware
-from .BasePathMiddleware import BasePathMiddleware
 from .BuildCql2FilterMiddleware import BuildCql2FilterMiddleware
 from .EnforceAuthMiddleware import EnforceAuthMiddleware
+from .ProcessLinksMiddleware import ProcessLinksMiddleware
+from .RemoveRootPathMiddleware import RemoveRootPathMiddleware
 from .UpdateOpenApiMiddleware import OpenApiMiddleware
 
 __all__ = [
     "AddProcessTimeHeaderMiddleware",
     "ApplyCql2FilterMiddleware",
     "AuthenticationExtensionMiddleware",
-    "BasePathMiddleware",
     "BuildCql2FilterMiddleware",
     "EnforceAuthMiddleware",
+    "ProcessLinksMiddleware",
+    "RemoveRootPathMiddleware",
     "OpenApiMiddleware",
 ]

--- a/src/stac_auth_proxy/middleware/__init__.py
+++ b/src/stac_auth_proxy/middleware/__init__.py
@@ -3,7 +3,7 @@
 from .AddProcessTimeHeaderMiddleware import AddProcessTimeHeaderMiddleware
 from .ApplyCql2FilterMiddleware import ApplyCql2FilterMiddleware
 from .AuthenticationExtensionMiddleware import AuthenticationExtensionMiddleware
-from .BasePathMiddleware import RemoveRootPathMiddleware
+from .BasePathMiddleware import BasePathMiddleware
 from .BuildCql2FilterMiddleware import BuildCql2FilterMiddleware
 from .EnforceAuthMiddleware import EnforceAuthMiddleware
 from .UpdateOpenApiMiddleware import OpenApiMiddleware
@@ -12,7 +12,7 @@ __all__ = [
     "AddProcessTimeHeaderMiddleware",
     "ApplyCql2FilterMiddleware",
     "AuthenticationExtensionMiddleware",
-    "RemoveRootPathMiddleware",
+    "BasePathMiddleware",
     "BuildCql2FilterMiddleware",
     "EnforceAuthMiddleware",
     "OpenApiMiddleware",

--- a/src/stac_auth_proxy/utils/stac.py
+++ b/src/stac_auth_proxy/utils/stac.py
@@ -1,0 +1,18 @@
+"""STAC-specific utilities."""
+
+from itertools import chain
+
+
+def get_links(data: dict) -> chain[dict]:  # type: ignore
+    """Get all links from a STAC response."""
+    return chain(
+        # Item/Collection
+        data.get("links", []),
+        # Collections/Items/Search
+        (
+            link
+            for prop in ["features", "collections"]
+            for object_with_links in data.get(prop, [])
+            for link in object_with_links.get("links", [])
+        ),
+    )

--- a/src/stac_auth_proxy/utils/stac.py
+++ b/src/stac_auth_proxy/utils/stac.py
@@ -3,7 +3,7 @@
 from itertools import chain
 
 
-def get_links(data: dict) -> chain[dict]:  # type: ignore
+def get_links(data: dict) -> chain[dict]:
     """Get all links from a STAC response."""
     return chain(
         # Item/Collection

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -201,7 +201,7 @@ def test_root_path_in_openapi_spec(source_api: FastAPI, source_api_server: str):
         root_path=root_path,
     )
     client = TestClient(app)
-    response = client.get(source_api.openapi_url)
+    response = client.get(root_path + source_api.openapi_url)
     assert response.status_code == 200
     openapi = response.json()
     assert "servers" in openapi

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -190,3 +190,33 @@ def test_auth_scheme_override(source_api: FastAPI, source_api_server: str):
     security_schemes = openapi.get("components", {}).get("securitySchemes", {})
     assert "oidcAuth" in security_schemes
     assert security_schemes["oidcAuth"] == custom_scheme
+
+
+def test_root_path_in_openapi_spec(source_api: FastAPI, source_api_server: str):
+    """When root_path is set, the OpenAPI spec includes the root path in the servers field."""
+    root_path = "/api/v1"
+    app = app_factory(
+        upstream_url=source_api_server,
+        openapi_spec_endpoint=source_api.openapi_url,
+        root_path=root_path,
+    )
+    client = TestClient(app)
+    response = client.get(source_api.openapi_url)
+    assert response.status_code == 200
+    openapi = response.json()
+    assert "servers" in openapi
+    assert openapi["servers"] == [{"url": root_path}]
+
+
+def test_no_root_path_in_openapi_spec(source_api: FastAPI, source_api_server: str):
+    """When root_path is not set, the OpenAPI spec does not include a servers field."""
+    app = app_factory(
+        upstream_url=source_api_server,
+        openapi_spec_endpoint=source_api.openapi_url,
+        root_path="",  # Empty string means no root path
+    )
+    client = TestClient(app)
+    response = client.get(source_api.openapi_url)
+    assert response.status_code == 200
+    openapi = response.json()
+    assert "servers" not in openapi

--- a/tests/test_process_links.py
+++ b/tests/test_process_links.py
@@ -1,0 +1,188 @@
+"""Tests for ProcessLinksMiddleware."""
+
+import pytest
+from starlette.requests import Request
+
+from stac_auth_proxy.middleware.ProcessLinksMiddleware import ProcessLinksMiddleware
+
+
+@pytest.fixture
+def middleware():
+    """Create a test instance of the middleware."""
+    return ProcessLinksMiddleware(
+        app=None,  # We don't need the actual app for these tests
+        upstream_url="http://upstream.example.com/api",
+        root_path="/proxy",
+    )
+
+
+@pytest.fixture
+def request_scope():
+    """Create a test request scope."""
+    return {
+        "type": "http",
+        "path": "/test",
+        "headers": [
+            (b"host", b"proxy.example.com"),
+            (b"content-type", b"application/json"),
+        ],
+    }
+
+
+def test_should_transform_response_json(middleware, request_scope):
+    """Test that JSON responses are transformed."""
+    request = Request(request_scope)
+    assert middleware.should_transform_response(request, request_scope)
+
+
+def test_should_transform_response_geojson(middleware, request_scope):
+    """Test that GeoJSON responses are transformed."""
+    request_scope["headers"] = [
+        (b"host", b"proxy.example.com"),
+        (b"content-type", b"application/geo+json"),
+    ]
+    request = Request(request_scope)
+    assert middleware.should_transform_response(request, request_scope)
+
+
+def test_should_transform_response_non_json(middleware, request_scope):
+    """Test that non-JSON responses are not transformed."""
+    request_scope["headers"] = [
+        (b"host", b"proxy.example.com"),
+        (b"content-type", b"text/plain"),
+    ]
+    request = Request(request_scope)
+    assert not middleware.should_transform_response(request, request_scope)
+
+
+def test_transform_json_with_upstream_path(middleware, request_scope):
+    """Test transforming links with upstream URL path."""
+    request = Request(request_scope)
+
+    data = {
+        "links": [
+            {"rel": "self", "href": "http://proxy.example.com/api/collections"},
+            {"rel": "root", "href": "http://proxy.example.com/api"},
+        ]
+    }
+
+    transformed = middleware.transform_json(data, request)
+
+    assert (
+        transformed["links"][0]["href"] == "http://proxy.example.com/proxy/collections"
+    )
+    assert transformed["links"][1]["href"] == "http://proxy.example.com/proxy"
+
+
+def test_transform_json_without_upstream_path(middleware, request_scope):
+    """Test transforming links without upstream URL path."""
+    middleware = ProcessLinksMiddleware(
+        app=None, upstream_url="http://upstream.example.com", root_path="/proxy"
+    )
+    request = Request(request_scope)
+
+    data = {
+        "links": [
+            {"rel": "self", "href": "http://proxy.example.com/collections"},
+            {"rel": "root", "href": "http://proxy.example.com/"},
+        ]
+    }
+
+    transformed = middleware.transform_json(data, request)
+
+    assert (
+        transformed["links"][0]["href"] == "http://proxy.example.com/proxy/collections"
+    )
+    assert transformed["links"][1]["href"] == "http://proxy.example.com/proxy/"
+
+
+def test_transform_json_without_root_path(middleware, request_scope):
+    """Test transforming links without root path."""
+    middleware = ProcessLinksMiddleware(
+        app=None, upstream_url="http://upstream.example.com/api", root_path=None
+    )
+    request = Request(request_scope)
+
+    data = {
+        "links": [
+            {"rel": "self", "href": "http://proxy.example.com/api/collections"},
+            {"rel": "root", "href": "http://proxy.example.com/api"},
+        ]
+    }
+
+    transformed = middleware.transform_json(data, request)
+
+    assert transformed["links"][0]["href"] == "http://proxy.example.com/collections"
+    assert transformed["links"][1]["href"] == "http://proxy.example.com"
+
+
+def test_transform_json_different_host(middleware, request_scope):
+    """Test that links with different hostnames are not transformed."""
+    request = Request(request_scope)
+
+    data = {
+        "links": [
+            {"rel": "self", "href": "http://other.example.com/api/collections"},
+            {"rel": "root", "href": "http://other.example.com/api"},
+        ]
+    }
+
+    transformed = middleware.transform_json(data, request)
+
+    assert transformed["links"][0]["href"] == "http://other.example.com/api/collections"
+    assert transformed["links"][1]["href"] == "http://other.example.com/api"
+
+
+def test_transform_json_invalid_link(middleware, request_scope):
+    """Test that invalid links are handled gracefully."""
+    request = Request(request_scope)
+
+    data = {
+        "links": [
+            {"rel": "self", "href": "not-a-url"},
+            {"rel": "root", "href": "http://proxy.example.com/api"},
+        ]
+    }
+
+    transformed = middleware.transform_json(data, request)
+
+    assert transformed["links"][0]["href"] == "not-a-url"
+    assert transformed["links"][1]["href"] == "http://proxy.example.com/proxy"
+
+
+def test_transform_json_nested_links(middleware, request_scope):
+    """Test transforming links in nested STAC objects."""
+    request = Request(request_scope)
+
+    data = {
+        "links": [
+            {"rel": "self", "href": "http://proxy.example.com/api"},
+        ],
+        "collections": [
+            {
+                "id": "test-collection",
+                "links": [
+                    {
+                        "rel": "self",
+                        "href": "http://proxy.example.com/api/collections/test-collection",
+                    },
+                    {
+                        "rel": "items",
+                        "href": "http://proxy.example.com/api/collections/test-collection/items",
+                    },
+                ],
+            }
+        ],
+    }
+
+    transformed = middleware.transform_json(data, request)
+
+    assert transformed["links"][0]["href"] == "http://proxy.example.com/proxy"
+    assert (
+        transformed["collections"][0]["links"][0]["href"]
+        == "http://proxy.example.com/proxy/collections/test-collection"
+    )
+    assert (
+        transformed["collections"][0]["links"][1]["href"]
+        == "http://proxy.example.com/proxy/collections/test-collection/items"
+    )

--- a/tests/test_remove_root_path.py
+++ b/tests/test_remove_root_path.py
@@ -1,0 +1,106 @@
+"""Tests for RemoveRootPathMiddleware."""
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+from starlette.types import Receive, Scope, Send
+
+from stac_auth_proxy.middleware.RemoveRootPathMiddleware import RemoveRootPathMiddleware
+
+
+class MockASGIApp:
+    """Mock ASGI application for testing."""
+
+    def __init__(self):
+        """Initialize the mock app."""
+        self.called = False
+        self.scope = None
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Mock ASGI call."""
+        self.called = True
+        self.scope = scope
+
+
+@pytest.mark.asyncio
+async def test_remove_root_path_middleware():
+    """Test that root path is removed from request path."""
+    mock_app = MockASGIApp()
+    middleware = RemoveRootPathMiddleware(mock_app, root_path="/api")
+
+    # Test with root path
+    scope = {
+        "type": "http",
+        "path": "/api/test",
+        "raw_path": b"/api/test",
+    }
+    await middleware(scope, None, None)
+    assert mock_app.called
+    assert mock_app.scope["path"] == "/test"
+    assert mock_app.scope["raw_path"] == b"/api/test"
+
+    # Test without root path
+    mock_app = MockASGIApp()
+    middleware = RemoveRootPathMiddleware(mock_app, root_path="/api")
+    scope = {
+        "type": "http",
+        "path": "/test",
+        "raw_path": b"/test",
+    }
+    await middleware(scope, None, None)
+    assert mock_app.called
+    assert mock_app.scope["path"] == "/test"
+    assert mock_app.scope["raw_path"] == b"/test"
+
+
+@pytest.mark.asyncio
+async def test_remove_root_path_middleware_non_http():
+    """Test that non-HTTP requests are passed through unchanged."""
+    mock_app = MockASGIApp()
+    middleware = RemoveRootPathMiddleware(mock_app, root_path="/api")
+
+    scope = {
+        "type": "websocket",
+        "path": "/api/test",
+    }
+    await middleware(scope, None, None)
+    assert mock_app.called
+    assert mock_app.scope["path"] == "/api/test"
+
+
+@pytest.mark.asyncio
+async def test_remove_root_path_middleware_empty_path():
+    """Test that empty path after root path removal is set to '/'."""
+    mock_app = MockASGIApp()
+    middleware = RemoveRootPathMiddleware(mock_app, root_path="/api")
+
+    scope = {
+        "type": "http",
+        "path": "/api",
+        "raw_path": b"/api",
+    }
+    await middleware(scope, None, None)
+    assert mock_app.called
+    assert mock_app.scope["path"] == "/"
+    assert mock_app.scope["raw_path"] == b"/api"
+
+
+def test_remove_root_path_middleware_integration():
+    """Test middleware integration with FastAPI."""
+    app = FastAPI()
+    app.add_middleware(RemoveRootPathMiddleware, root_path="/api")
+
+    @app.get("/test")
+    async def test_endpoint():
+        return {"message": "test"}
+
+    client = TestClient(app)
+
+    # Test with root path
+    response = client.get("/api/test")
+    assert response.status_code == 200
+    assert response.json() == {"message": "test"}
+
+    # Test without root path
+    response = client.get("/test")
+    assert response.status_code == 404  # Should not find the endpoint

--- a/tests/test_remove_root_path.py
+++ b/tests/test_remove_root_path.py
@@ -39,19 +39,6 @@ async def test_remove_root_path_middleware():
     assert mock_app.scope["path"] == "/test"
     assert mock_app.scope["raw_path"] == b"/api/test"
 
-    # Test without root path
-    mock_app = MockASGIApp()
-    middleware = RemoveRootPathMiddleware(mock_app, root_path="/api")
-    scope = {
-        "type": "http",
-        "path": "/test",
-        "raw_path": b"/test",
-    }
-    await middleware(scope, None, None)
-    assert mock_app.called
-    assert mock_app.scope["path"] == "/test"
-    assert mock_app.scope["raw_path"] == b"/test"
-
 
 @pytest.mark.asyncio
 async def test_remove_root_path_middleware_non_http():


### PR DESCRIPTION
Enable the proxy to be served from a configurable non-root path (e.g. `/stac`).  This is entirely independent of the path from which the upstream API is served.

This involves:

* Processing the `href` of any link in the response matching the upstream host, removing the `upstream_url` path and adding the `root_path` if it exists
* Removing the `root_path` from the request before it is sent to the upstream server
* Adding a servers field in OpenAPI spec with `root_path` if it exists