### PR TITLE
feat: support customizing OpenAPI auth scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,19 @@ The application is configurable via environment variables.
     - **Type:** boolean
     - **Required:** No, defaults to `true`
     - **Example:** `false`, `1`, `True`
+- OpenAPI
   - **`OPENAPI_SPEC_ENDPOINT`**, path of OpenAPI specification, used for augmenting spec response with auth configuration
     - **Type:** string or null
     - **Required:** No, defaults to `null` (disabled)
     - **Example:** `/api`
+  - **`OPENAPI_AUTH_SCHEME_NAME`**, name of the auth scheme to use in the OpenAPI spec
+    - **Type:** string
+    - **Required:** No, defaults to `oidcAuth`
+    - **Example:** `jwtAuth`
+  - **`OPENAPI_AUTH_SCHEME_OVERRIDE`**, override for the auth scheme in the OpenAPI spec
+    - **Type:** JSON object
+    - **Required:** No, defaults to `null` (disabled)
+    - **Example:** `{"type": "http", "scheme": "bearer", "bearerFormat": "JWT", "description": "Paste your raw JWT here. This API uses Bearer token authorization.\n"}`
 - Filtering
   - **`ITEMS_FILTER_CLS`**, CQL2 expression generator for item-level filtering
     - **Type:** JSON object with class configuration
@@ -139,7 +148,7 @@ The application is configurable via environment variables.
   - **`ITEMS_FILTER_KWARGS`**, Keyword arguments for CQL2 expression generator
     - **Type:** Dictionary of keyword arguments used to initialize the class
     - **Required:** No, defaults to `{}`
-    - **Example:** `{ "field_name": "properties.organization" }`
+    - **Example:** `{"field_name": "properties.organization"}`
 
 ### Customization
 

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -103,6 +103,8 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             public_endpoints=settings.public_endpoints,
             private_endpoints=settings.private_endpoints,
             default_public=settings.default_public,
+            auth_scheme_name=settings.openapi_auth_scheme_name,
+            auth_scheme_override=settings.openapi_auth_scheme_override,
         )
 
     if settings.items_filter:

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -38,14 +38,17 @@ class Settings(BaseSettings):
     oidc_discovery_url: HttpUrl
     oidc_discovery_internal_url: HttpUrl
 
+    healthz_prefix: str = Field(pattern=_PREFIX_PATTERN, default="/healthz")
     wait_for_upstream: bool = True
     check_conformance: bool = True
     enable_compression: bool = True
-    enable_authentication_extension: bool = True
-    healthz_prefix: str = Field(pattern=_PREFIX_PATTERN, default="/healthz")
+
     openapi_spec_endpoint: Optional[str] = Field(pattern=_PREFIX_PATTERN, default=None)
+    openapi_auth_scheme_name: str = "oidcAuth"
+    openapi_auth_scheme_override: Optional[dict] = None
 
     # Auth
+    enable_authentication_extension: bool = True
     default_public: bool = False
     public_endpoints: EndpointMethodsNoScope = {
         r"^/api.html$": ["GET"],


### PR DESCRIPTION
Currently, we inject an OIDC auth scheme into the OpenAPI spec.  However, users may want to run the STAC Auth Proxy to apply auth for tokens that are generated elsewhere (e.g. tokens that can be validated with a JWKS, but are not generated via the `/token` or `/authorization` endpoint).  As such, this PR enables the manual override of the auth scheme that we inject into the OpenAPI doc, configurable via env vars.