### PR TITLE
feat: enable hosting custom Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,10 @@ The application is configurable via environment variables.
     - **Type:** JSON object
     - **Required:** No, defaults to `null` (disabled)
     - **Example:** `{"type": "http", "scheme": "bearer", "bearerFormat": "JWT", "description": "Paste your raw JWT here. This API uses Bearer token authorization.\n"}`
-  - **`SWAGGER_UI_URL`**, path of Swagger UI, used for augmenting spec response with auth configuration
+  - **`SWAGGER_UI_ENDPOINT`**, path of Swagger UI, used for augmenting spec response with auth configuration
     - **Type:** string or null
     - **Required:** No, defaults to `/api.html`
     - **Example:** `/api`
-  - **`SWAGGER_UI_TITLE`**, title of the Swagger UI
-    - **Type:** string
-    - **Required:** No, defaults to `STAC API`
-    - **Example:** `Foo API`
   - **`SWAGGER_UI_INIT_OAUTH`**, initialization options for the [Swagger UI OAuth2 configuration](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/)
     - **Type:** JSON object
     - **Required:** No, defaults to `null` (disabled)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ The application is configurable via environment variables.
     - **Type:** JSON object
     - **Required:** No, defaults to `null` (disabled)
     - **Example:** `{"type": "http", "scheme": "bearer", "bearerFormat": "JWT", "description": "Paste your raw JWT here. This API uses Bearer token authorization.\n"}`
+  - **`SWAGGER_UI_URL`**, path of Swagger UI, used for augmenting spec response with auth configuration
+    - **Type:** string or null
+    - **Required:** No, defaults to `/api.html`
+    - **Example:** `/api`
+  - **`SWAGGER_UI_TITLE`**, title of the Swagger UI
+    - **Type:** string
+    - **Required:** No, defaults to `STAC API`
+    - **Example:** `Foo API`
+  - **`SWAGGER_UI_INIT_OAUTH`**, initialization options for the [Swagger UI OAuth2 configuration](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/)
+    - **Type:** JSON object
+    - **Required:** No, defaults to `null` (disabled)
+    - **Example:** `{"clientId": "stac-auth-proxy", "usePkceWithAuthorizationCodeGrant": true}`
 - Filtering
   - **`ITEMS_FILTER_CLS`**, CQL2 expression generator for item-level filtering
     - **Type:** JSON object with class configuration

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -92,7 +92,6 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
                 openapi_url=settings.openapi_spec_endpoint,
                 title=settings.swagger_ui_title,
                 init_oauth=settings.swagger_ui_init_oauth,
-                parameters=settings.swagger_ui_parameters,
             ).route,
             include_in_schema=False,
         )

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -78,12 +78,12 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     # Handlers (place catch-all proxy handler last)
     #
 
-    if settings.swagger_ui_url:
+    if settings.swagger_ui_endpoint:
         assert (
             settings.openapi_spec_endpoint
         ), "openapi_spec_endpoint must be set when using swagger_ui_url"
         app.add_route(
-            settings.swagger_ui_url,
+            settings.swagger_ui_endpoint,
             SwaggerUI(
                 openapi_url=settings.openapi_spec_endpoint,
                 title=settings.swagger_ui_title,

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -81,12 +81,11 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     if settings.swagger_ui_endpoint:
         assert (
             settings.openapi_spec_endpoint
-        ), "openapi_spec_endpoint must be set when using swagger_ui_url"
+        ), "openapi_spec_endpoint must be set when using swagger_ui_endpoint"
         app.add_route(
             settings.swagger_ui_endpoint,
             SwaggerUI(
                 openapi_url=settings.openapi_spec_endpoint,
-                title=settings.swagger_ui_title,
                 init_oauth=settings.swagger_ui_init_oauth,
             ).route,
             include_in_schema=False,

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -68,10 +68,6 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
 
     app = FastAPI(
         openapi_url=None,  # Disable OpenAPI schema endpoint, we want to serve upstream's schema
-        swagger_ui_parameters={
-            "usePkceWithAuthorizationCodeGrant": True,
-            "clientId": "stac-auth-proxy",
-        },
         lifespan=lifespan,
         root_path=settings.root_path,
     )

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -46,12 +46,10 @@ class Settings(BaseSettings):
     enable_compression: bool = True
 
     # OpenAPI / Swagger UI
-    openapi_spec_endpoint: Optional[str] = Field(
-        pattern=_PREFIX_PATTERN, default="/api"
-    )
+    openapi_spec_endpoint: Optional[str] = Field(pattern=_PREFIX_PATTERN, default=None)
     openapi_auth_scheme_name: str = "oidcAuth"
     openapi_auth_scheme_override: Optional[dict] = None
-    swagger_ui_endpoint: Optional[str] = "/api.html"
+    swagger_ui_endpoint: Optional[str] = None
     swagger_ui_init_oauth: dict = Field(default_factory=dict)
 
     # Auth

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -54,7 +54,6 @@ class Settings(BaseSettings):
     swagger_ui_url: Optional[str] = "/api.html"
     swagger_ui_title: Optional[str] = "STAC API"
     swagger_ui_init_oauth: dict = Field(default_factory=dict)
-    swagger_ui_parameters: dict = Field(default_factory=dict)
 
     # Auth
     enable_authentication_extension: bool = True

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -51,8 +51,8 @@ class Settings(BaseSettings):
     )
     openapi_auth_scheme_name: str = "oidcAuth"
     openapi_auth_scheme_override: Optional[dict] = None
-    swagger_ui_url: str = "/api.html"
-    swagger_ui_title: str = "STAC API"
+    swagger_ui_url: Optional[str] = "/api.html"
+    swagger_ui_title: Optional[str] = "STAC API"
     swagger_ui_init_oauth: dict = Field(default_factory=dict)
     swagger_ui_parameters: dict = Field(default_factory=dict)
 

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -51,8 +51,7 @@ class Settings(BaseSettings):
     )
     openapi_auth_scheme_name: str = "oidcAuth"
     openapi_auth_scheme_override: Optional[dict] = None
-    swagger_ui_url: Optional[str] = "/api.html"
-    swagger_ui_title: Optional[str] = "STAC API"
+    swagger_ui_endpoint: Optional[str] = "/api.html"
     swagger_ui_init_oauth: dict = Field(default_factory=dict)
 
     # Auth

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -45,9 +45,16 @@ class Settings(BaseSettings):
     check_conformance: bool = True
     enable_compression: bool = True
 
-    openapi_spec_endpoint: Optional[str] = Field(pattern=_PREFIX_PATTERN, default=None)
+    # OpenAPI / Swagger UI
+    openapi_spec_endpoint: Optional[str] = Field(
+        pattern=_PREFIX_PATTERN, default="/api"
+    )
     openapi_auth_scheme_name: str = "oidcAuth"
     openapi_auth_scheme_override: Optional[dict] = None
+    swagger_ui_url: str = "/api.html"
+    swagger_ui_title: str = "STAC API"
+    swagger_ui_init_oauth: dict = Field(default_factory=dict)
+    swagger_ui_parameters: dict = Field(default_factory=dict)
 
     # Auth
     enable_authentication_extension: bool = True

--- a/src/stac_auth_proxy/handlers/__init__.py
+++ b/src/stac_auth_proxy/handlers/__init__.py
@@ -2,5 +2,6 @@
 
 from .healthz import HealthzHandler
 from .reverse_proxy import ReverseProxyHandler
+from .swagger_ui import SwaggerUI
 
-__all__ = ["ReverseProxyHandler", "HealthzHandler"]
+__all__ = ["ReverseProxyHandler", "HealthzHandler", "SwaggerUI"]

--- a/src/stac_auth_proxy/handlers/swagger_ui.py
+++ b/src/stac_auth_proxy/handlers/swagger_ui.py
@@ -22,6 +22,7 @@ class SwaggerUI:
     openapi_url: str
     title: Optional[str] = "STAC API"
     init_oauth: dict = field(default_factory=dict)
+    parameters: dict = field(default_factory=dict)
     oauth2_redirect_url: str = "/docs/oauth2-redirect"
 
     async def route(self, req: Request) -> HTMLResponse:
@@ -36,5 +37,5 @@ class SwaggerUI:
             title=f"{self.title} - Swagger UI",
             oauth2_redirect_url=oauth2_redirect_url,
             init_oauth=self.init_oauth,
-            swagger_ui_parameters=None,
+            swagger_ui_parameters=self.parameters,
         )

--- a/src/stac_auth_proxy/handlers/swagger_ui.py
+++ b/src/stac_auth_proxy/handlers/swagger_ui.py
@@ -14,10 +14,7 @@ class SwaggerUI:
 
     openapi_url: str
     title: Optional[str] = "STAC API"
-    # https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/
     init_oauth: dict = field(default_factory=dict)
-    # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
-    parameters: dict = field(default_factory=dict)
     oauth2_redirect_url: str = "/docs/oauth2-redirect"
 
     async def route(self, req: Request) -> HTMLResponse:
@@ -32,5 +29,5 @@ class SwaggerUI:
             title=f"{self.title} - Swagger UI",
             oauth2_redirect_url=oauth2_redirect_url,
             init_oauth=self.init_oauth,
-            swagger_ui_parameters=self.parameters,
+            swagger_ui_parameters=None,
         )

--- a/src/stac_auth_proxy/handlers/swagger_ui.py
+++ b/src/stac_auth_proxy/handlers/swagger_ui.py
@@ -1,0 +1,35 @@
+"""Swagger UI handler."""
+
+from dataclasses import dataclass, field
+
+from fastapi.openapi.docs import get_swagger_ui_html
+from starlette.requests import Request
+from starlette.responses import HTMLResponse
+
+
+@dataclass
+class SwaggerUI:
+    """Swagger UI handler."""
+
+    openapi_url: str
+    title: str = "STAC API"
+    # https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/
+    init_oauth: dict = field(default_factory=dict)
+    # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
+    parameters: dict = field(default_factory=dict)
+    oauth2_redirect_url: str = "/docs/oauth2-redirect"
+
+    async def route(self, req: Request) -> HTMLResponse:
+        """Route handler."""
+        root_path = req.scope.get("root_path", "").rstrip("/")
+        openapi_url = root_path + self.openapi_url
+        oauth2_redirect_url = self.oauth2_redirect_url
+        if oauth2_redirect_url:
+            oauth2_redirect_url = root_path + oauth2_redirect_url
+        return get_swagger_ui_html(
+            openapi_url=openapi_url,
+            title=f"{self.title} - Swagger UI",
+            oauth2_redirect_url=oauth2_redirect_url,
+            init_oauth=self.init_oauth,
+            swagger_ui_parameters=self.parameters,
+        )

--- a/src/stac_auth_proxy/handlers/swagger_ui.py
+++ b/src/stac_auth_proxy/handlers/swagger_ui.py
@@ -1,4 +1,11 @@
-"""Swagger UI handler."""
+"""
+In order to allow customization fo the Swagger UI's OAuth2 configuration, we support
+overriding the default handler. This is useful for adding custom parameters such as
+`usePkceWithAuthorizationCodeGrant` or `clientId`.
+
+See:
+- https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/
+"""
 
 from dataclasses import dataclass, field
 from typing import Optional

--- a/src/stac_auth_proxy/handlers/swagger_ui.py
+++ b/src/stac_auth_proxy/handlers/swagger_ui.py
@@ -1,6 +1,7 @@
 """Swagger UI handler."""
 
 from dataclasses import dataclass, field
+from typing import Optional
 
 from fastapi.openapi.docs import get_swagger_ui_html
 from starlette.requests import Request
@@ -12,7 +13,7 @@ class SwaggerUI:
     """Swagger UI handler."""
 
     openapi_url: str
-    title: str = "STAC API"
+    title: Optional[str] = "STAC API"
     # https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/
     init_oauth: dict = field(default_factory=dict)
     # https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -15,7 +15,7 @@ def test_no_openapi_spec_endpoint(source_api_server: str):
     app = app_factory(
         upstream_url=source_api_server,
         openapi_spec_endpoint=None,
-        swagger_ui_url=None,
+        swagger_ui_endpoint=None,
     )
     client = TestClient(app)
     response = client.get("/api")

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -15,7 +15,6 @@ def test_no_openapi_spec_endpoint(source_api_server: str):
     app = app_factory(
         upstream_url=source_api_server,
         openapi_spec_endpoint=None,
-        swagger_ui_endpoint=None,
     )
     client = TestClient(app)
     response = client.get("/api")

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -15,6 +15,7 @@ def test_no_openapi_spec_endpoint(source_api_server: str):
     app = app_factory(
         upstream_url=source_api_server,
         openapi_spec_endpoint=None,
+        swagger_ui_url=None,
     )
     client = TestClient(app)
     response = client.get("/api")


### PR DESCRIPTION
Given that the vanilla `stac-fastapi-pgstac` application does not support specifying `init_oauth` (which makes sense, being that there's no authentication within the vanilla application), it does make sense to permit creating our own Swagger UI within this service.

related to #15 