### PR TITLE
wip: workflow to test helm deploy

### DIFF
--- a/.github/workflows/test-helm.yaml
+++ b/.github/workflows/test-helm.yaml
@@ -1,0 +1,37 @@
+name: Test Helm Chart
+
+on:
+  push:
+    paths:
+      - 'helm/**'
+  pull_request:
+    paths:
+      - 'helm/**'
+
+jobs:
+  test-helm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Kubernetes tools
+        uses: azure/setup-kubectl@v3
+      
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.13.2'
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.8.0
+
+      - name: Run Helm tests
+        run: |
+          # Install chart with test values
+          helm upgrade --install stac-auth-proxy ./helm \
+            --values ./helm/test-values.yaml \
+            --wait \
+            --timeout 2m
+
+          # Run helm tests
+          helm test stac-auth-proxy --timeout 2m

--- a/helm/templates/tests/test-auth.yaml
+++ b/helm/templates/tests/test-auth.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "stac-auth-proxy.fullname" . }}-test-auth"
+  labels:
+    {{- include "stac-auth-proxy.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  containers:
+    - name: curl
+      image: curlimages/curl
+      command: 
+        - /bin/sh
+        - -c
+        - |
+          # Make request and check for 401
+          response=$(curl -o /dev/null -s -w "%{http_code}" http://{{ include "stac-auth-proxy.fullname" . }}:{{ .Values.service.port }}/)
+          if [ "$response" = "401" ]; then
+            echo "Successfully got 401 Unauthorized as expected"
+            exit 0
+          else
+            echo "Expected 401 but got $response"
+            exit 1
+          fi
+  restartPolicy: Never

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "stac-auth-proxy.fullname" . }}-test-connection"
+  labels:
+    {{- include "stac-auth-proxy.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "stac-auth-proxy.fullname" . }}:{{ .Values.service.port }}/healthz']
+  restartPolicy: Never

--- a/helm/templates/tests/test-service.yaml
+++ b/helm/templates/tests/test-service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "stac-auth-proxy.fullname" . }}-test-service"
+  labels:
+    {{- include "stac-auth-proxy.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  containers:
+    - name: test
+      image: busybox
+      command:
+        - sh
+        - -c
+        - |
+          # Test service type is set to a valid value
+          service_type="{{ .Values.service.type }}"
+          valid_types="ClusterIP NodePort LoadBalancer"
+          
+          if ! echo "$valid_types" | grep -w "$service_type" > /dev/null; then
+            echo "Invalid service type: $service_type"
+            exit 1
+          fi
+          
+          # Test service port is set and is a valid port number
+          port="{{ .Values.service.port }}"
+          if [ -z "$port" ] || [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+            echo "Invalid service port: $port"
+            exit 1
+          fi
+          
+          echo "Service configuration is valid"
+  restartPolicy: Never


### PR DESCRIPTION
Addresses https://github.com/developmentseed/stac-auth-proxy/issues/54

Creates some "test" helm charts that should get run as part of a `helm test` that verifies that the service is up and does a basic check that responses are 401 Unauthorized as expected.

We can think about integrating an actual auth token with an `oidc` endpoint down the line to also test successful authentication.

@emmanuelmathot what do you think of this approach and using `helm test` to run the tests? It seemed quite nice, but will try running things in CI, etc. and see if it makes sense to keep with this approach. Let me know if you have strong opinions against this kind of approach.

cc @sunu 