### PR TITLE
feat: allow customize filter paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 STAC Auth Proxy is a proxy API that mediates between the client and your internally accessible STAC API to provide flexible authentication, authorization, and content-filtering mechanisms.
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > **We would :heart: to hear from you!**
 > Please [join the discussion](https://github.com/developmentseed/eoAPI/discussions/209) and let us know how you're using eoAPI! This helps us improve the project for you and others.
 > If you prefer to remain anonymous, you can email us at eoapi@developmentseed.org, and we'll be happy to post a summary on your behalf.
@@ -171,6 +171,10 @@ The application is configurable via environment variables.
     - **Type:** Dictionary of keyword arguments used to initialize the class
     - **Required:** No, defaults to `{}`
     - **Example:** `{"field_name": "properties.organization"}`
+  - **`ITEMS_FILTER_PATH`**, Regex pattern used to identify request paths that require the application of the items filter
+    - **Type:** Regex string
+    - **Required:** No, defaults to `^(/collections/([^/]+)/items(/[^/]+)?$|/search$)`
+    - **Example:** `^(/collections/([^/]+)/items(/[^/]+)?$|/search$|/custom$)`
   - **`COLLECTIONS_FILTER_CLS`**, CQL2 expression generator for collection-level filtering
     - **Type:** JSON object with class configuration
     - **Required:** No, defaults to `null` (disabled)
@@ -183,6 +187,10 @@ The application is configurable via environment variables.
     - **Type:** Dictionary of keyword arguments used to initialize the class
     - **Required:** No, defaults to `{}`
     - **Example:** `{"field_name": "properties.organization"}`
+  - **`COLLECTIONS_FILTER_PATH`**, Regex pattern used to identify request paths that require the application of the collections filter
+    - **Type:** Regex string
+    - **Required:** No, defaults to `^/collections(/[^/]+)?$`
+    - **Example:** `^.*?/collections(/[^/]+)?$`
 
 ### Tips
 

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -141,6 +141,8 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             collections_filter=(
                 settings.collections_filter() if settings.collections_filter else None
             ),
+            collections_filter_path=settings.collections_filter_path,
+            items_filter_path=settings.items_filter_path,
         )
 
     app.add_middleware(

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -74,7 +74,9 @@ class Settings(BaseSettings):
 
     # Filters
     items_filter: Optional[ClassInput] = None
+    items_filter_path: str = r"^(/collections/([^/]+)/items(/[^/]+)?$|/search$)"
     collections_filter: Optional[ClassInput] = None
+    collections_filter_path: str = r"^/collections(/[^/]+)?$"
 
     model_config = SettingsConfigDict(
         env_nested_delimiter="_",


### PR DESCRIPTION
Support customizing filter paths.  This comes in hand when doing something such as supporting dynamic prefixes for virtualized STAC catalogs.