### PR TITLE
fix: fix status check for 2xx responses

### DIFF
--- a/src/stac_auth_proxy/middleware/AuthenticationExtensionMiddleware.py
+++ b/src/stac_auth_proxy/middleware/AuthenticationExtensionMiddleware.py
@@ -57,7 +57,7 @@ class AuthenticationExtensionMiddleware(JsonResponseMiddleware):
                     ]
                 ),
             )
-            and 200 >= scope["status"] < 300
+            and 200 <= scope["status"] < 300
         )
 
     def transform_json(self, data: dict[str, Any], request: Request) -> dict[str, Any]:

--- a/src/stac_auth_proxy/middleware/UpdateOpenApiMiddleware.py
+++ b/src/stac_auth_proxy/middleware/UpdateOpenApiMiddleware.py
@@ -42,7 +42,7 @@ class OpenApiMiddleware(JsonResponseMiddleware):
                     ),
                 ]
             )
-            and 200 >= scope["status"] < 300
+            and 200 <= scope["status"] < 300
         )
 
     def transform_json(self, data: dict[str, Any], request: Request) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- fix 2xx status comparison logic in AuthenticationExtensionMiddleware
- fix 2xx status comparison logic in UpdateOpenApiMiddleware

## Testing
- `pytest -q tests/test_openapi.py::test_no_openapi_spec_endpoint -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_6859a6df1404832e9cb300eb8e944b16