### PR TITLE
fix: process links w/o the prefix

### DIFF
--- a/src/stac_auth_proxy/middleware/ProcessLinksMiddleware.py
+++ b/src/stac_auth_proxy/middleware/ProcessLinksMiddleware.py
@@ -55,7 +55,9 @@ class ProcessLinksMiddleware(JsonResponseMiddleware):
                 # Remove the upstream_url path from the link if it exists
                 if urlparse(self.upstream_url).path != "/":
                     parsed_link = parsed_link._replace(
-                        path=parsed_link.path[len(urlparse(self.upstream_url).path) :]
+                        path=str(parsed_link.path).replace(
+                            str(urlparse(self.upstream_url).path), ""
+                        )
                     )
 
                 # Add the root_path to the link if it exists

--- a/src/stac_auth_proxy/middleware/ProcessLinksMiddleware.py
+++ b/src/stac_auth_proxy/middleware/ProcessLinksMiddleware.py
@@ -53,11 +53,12 @@ class ProcessLinksMiddleware(JsonResponseMiddleware):
                     continue
 
                 # Remove the upstream_url path from the link if it exists
-                if urlparse(self.upstream_url).path != "/":
+                parsed_upstream_url = urlparse(self.upstream_url)
+                if parsed_upstream_url.path != "/" and parsed_link.path.startswith(
+                    parsed_upstream_url.path
+                ):
                     parsed_link = parsed_link._replace(
-                        path=str(parsed_link.path).replace(
-                            str(urlparse(self.upstream_url).path), ""
-                        )
+                        path=parsed_link.path[len(parsed_upstream_url.path) :]
                     )
 
                 # Add the root_path to the link if it exists

--- a/tests/test_process_links.py
+++ b/tests/test_process_links.py
@@ -186,3 +186,19 @@ def test_transform_json_nested_links(middleware, request_scope):
         transformed["collections"][0]["links"][1]["href"]
         == "http://proxy.example.com/proxy/collections/test-collection/items"
     )
+
+
+def test_transform_without_prefix(request_scope):
+    """Sometimes the upstream url will have a path, but the links won't."""
+    middleware = ProcessLinksMiddleware(
+        app=None, upstream_url="http://upstream.example.com/prod/", root_path=""
+    )
+    request = Request(request_scope)
+
+    data = {
+        "links": [
+            {"rel": "data", "href": "http://proxy.example.com/collections"},
+        ]
+    }
+    transformed = middleware.transform_json(data, request)
+    assert transformed["links"][0]["href"] == "http://proxy.example.com/collections"


### PR DESCRIPTION
There's times when the underlying STAC API might not have a path on its root URL, but **stac-auth-proxy** has a path on its `upstream_url`; one such case is if there's an API Gateway in the way. This patch uses string replacement for link rewriting, rather than slicing, to handle these cases while preserving previous behavior.