### PR TITLE
fix: ensure OPTIONS requests are sent upstream without auth check

### DIFF
--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -104,7 +104,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             upstream=str(settings.upstream_url),
             override_host=settings.override_host,
         ).proxy_request,
-        methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+        methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     )
 
     #

--- a/src/stac_auth_proxy/middleware/EnforceAuthMiddleware.py
+++ b/src/stac_auth_proxy/middleware/EnforceAuthMiddleware.py
@@ -85,6 +85,8 @@ class EnforceAuthMiddleware:
             return await self.app(scope, receive, send)
 
         request = Request(scope)
+
+        # Skip authentication for OPTIONS requests, https://fetch.spec.whatwg.org/#cors-protocol-and-credentials
         if request.method == "OPTIONS":
             return await self.app(scope, receive, send)
 

--- a/src/stac_auth_proxy/middleware/EnforceAuthMiddleware.py
+++ b/src/stac_auth_proxy/middleware/EnforceAuthMiddleware.py
@@ -85,6 +85,9 @@ class EnforceAuthMiddleware:
             return await self.app(scope, receive, send)
 
         request = Request(scope)
+        if request.method == "OPTIONS":
+            return await self.app(scope, receive, send)
+
         match = find_match(
             request.url.path,
             request.method,
@@ -148,7 +151,11 @@ class EnforceAuthMiddleware:
                 # NOTE: Audience validation MUST match audience claim if set in token (https://pyjwt.readthedocs.io/en/stable/changelog.html?highlight=audience#id40)
                 audience=self.allowed_jwt_audiences,
             )
-        except (jwt.exceptions.InvalidTokenError, jwt.exceptions.DecodeError) as e:
+        except (
+            jwt.exceptions.InvalidTokenError,
+            jwt.exceptions.DecodeError,
+            jwt.exceptions.PyJWKClientError,
+        ) as e:
             logger.error("InvalidTokenError: %r", e)
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/src/stac_auth_proxy/middleware/UpdateOpenApiMiddleware.py
+++ b/src/stac_auth_proxy/middleware/UpdateOpenApiMiddleware.py
@@ -62,6 +62,9 @@ class OpenApiMiddleware(JsonResponseMiddleware):
         # Add security to private endpoints
         for path, method_config in data["paths"].items():
             for method, config in method_config.items():
+                # if method == "options":
+                #     # OPTIONS requests are not authenticated, https://fetch.spec.whatwg.org/#cors-protocol-and-credentials
+                #     continue
                 match = find_match(
                     path,
                     method,

--- a/src/stac_auth_proxy/middleware/UpdateOpenApiMiddleware.py
+++ b/src/stac_auth_proxy/middleware/UpdateOpenApiMiddleware.py
@@ -62,9 +62,9 @@ class OpenApiMiddleware(JsonResponseMiddleware):
         # Add security to private endpoints
         for path, method_config in data["paths"].items():
             for method, config in method_config.items():
-                # if method == "options":
-                #     # OPTIONS requests are not authenticated, https://fetch.spec.whatwg.org/#cors-protocol-and-credentials
-                #     continue
+                if method == "options":
+                    # OPTIONS requests are not authenticated, https://fetch.spec.whatwg.org/#cors-protocol-and-credentials
+                    continue
                 match = find_match(
                     path,
                     method,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,35 +87,50 @@ def source_api():
 
     # Default responses for each endpoint
     default_responses = {
-        "/": {"GET": {"id": "Response from GET@"}},
-        "/conformance": {"GET": {"conformsTo": ["http://example.com/conformance"]}},
-        "/queryables": {"GET": {"queryables": {}}},
+        "/": {
+            "GET": {"id": "Response from GET@"},
+            "OPTIONS": {"id": "Response from OPTIONS@"},
+        },
+        "/conformance": {
+            "GET": {"conformsTo": ["http://example.com/conformance"]},
+            "OPTIONS": {"id": "Response from OPTIONS@"},
+        },
+        "/queryables": {
+            "GET": {"queryables": {}},
+            "OPTIONS": {"id": "Response from OPTIONS@"},
+        },
         "/search": {
             "GET": {"type": "FeatureCollection", "features": []},
             "POST": {"type": "FeatureCollection", "features": []},
+            "OPTIONS": {"id": "Response from OPTIONS@"},
         },
         "/collections": {
             "GET": {"collections": []},
             "POST": {"id": "Response from POST@"},
+            "OPTIONS": {"id": "Response from OPTIONS@"},
         },
         "/collections/{collection_id}": {
             "GET": {"id": "Response from GET@"},
             "PUT": {"id": "Response from PUT@"},
             "PATCH": {"id": "Response from PATCH@"},
             "DELETE": {"id": "Response from DELETE@"},
+            "OPTIONS": {"id": "Response from OPTIONS@"},
         },
         "/collections/{collection_id}/items": {
             "GET": {"type": "FeatureCollection", "features": []},
             "POST": {"id": "Response from POST@"},
+            "OPTIONS": {"id": "Response from OPTIONS@"},
         },
         "/collections/{collection_id}/items/{item_id}": {
             "GET": {"id": "Response from GET@"},
             "PUT": {"id": "Response from PUT@"},
             "PATCH": {"id": "Response from PATCH@"},
             "DELETE": {"id": "Response from DELETE@"},
+            "OPTIONS": {"id": "Response from OPTIONS@"},
         },
         "/collections/{collection_id}/bulk_items": {
             "POST": {"id": "Response from POST@"},
+            "OPTIONS": {"id": "Response from OPTIONS@"},
         },
     }
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -140,16 +140,23 @@ def test_oidc_in_openapi_spec_public_endpoints(
 
     openapi = client.get(source_api.openapi_url).raise_for_status().json()
 
-    expected_auth = {"/queryables": ["GET"]}
+    expected_required_auth = {"/queryables": ["GET"]}
     for path, method_config in openapi["paths"].items():
         for method, config in method_config.items():
             security = config.get("security")
-            if security:
-                assert path not in expected_auth
+            if method == "options":
+                assert not security, "OPTIONS requests should not be authenticated"
+            elif security:
+                assert (
+                    path not in expected_required_auth
+                ), f"Path {path} should not require authentication"
             else:
-                assert path in expected_auth
+                assert (
+                    path in expected_required_auth
+                ), f"Path {path} should require authentication"
                 assert any(
-                    method.casefold() == m.casefold() for m in expected_auth[path]
+                    method.casefold() == m.casefold()
+                    for m in expected_required_auth[path]
                 )
 
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -129,7 +129,7 @@ def test_oidc_in_openapi_spec_public_endpoints(
     source_api: FastAPI, source_api_server: str
 ):
     """When OpenAPI spec endpoint is set & endpoints are marked public, those endpoints are not marked private in the spec."""
-    public = {r"^/queryables$": ["GET"], r"^/api": ["GET"]}
+    public = {r"^/queryables$": ["GET"], r"^/api$": ["GET"]}
     app = app_factory(
         upstream_url=source_api_server,
         openapi_spec_endpoint=source_api.openapi_url,
@@ -148,7 +148,7 @@ def test_oidc_in_openapi_spec_public_endpoints(
             if method == "options":
                 assert (
                     not security
-                ), "OPTIONS requests should not require authentication"
+                ), f"OPTIONS {path} requests should not require authentication"
                 continue
 
             if security:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -144,20 +144,25 @@ def test_oidc_in_openapi_spec_public_endpoints(
     for path, method_config in openapi["paths"].items():
         for method, config in method_config.items():
             security = config.get("security")
+
             if method == "options":
-                assert not security, "OPTIONS requests should not be authenticated"
-            elif security:
+                assert (
+                    not security
+                ), "OPTIONS requests should not require authentication"
+                continue
+
+            if security:
                 assert (
                     path not in expected_required_auth
                 ), f"Path {path} should not require authentication"
-            else:
-                assert (
-                    path in expected_required_auth
-                ), f"Path {path} should require authentication"
-                assert any(
-                    method.casefold() == m.casefold()
-                    for m in expected_required_auth[path]
-                )
+                continue
+
+            assert (
+                path in expected_required_auth
+            ), f"Path {path} should require authentication"
+            assert any(
+                method.casefold() == m.casefold() for m in expected_required_auth[path]
+            )
 
 
 def test_auth_scheme_name_override(source_api: FastAPI, source_api_server: str):


### PR DESCRIPTION
Allow OPTIONS requests through without performing auth checks.

Also, ensure that we don't add auth requirements to OPTIONS endpoints when augment OpenAPI spec.

Finally, Claude helped to write tests and recommended we catch `jwt.exceptions.PyJWKClientError` errors when validating tokens (this came up when it added a test with invalid tokens)

Closes #75 