### PR TITLE
refactor(config): restructure settings classes for STAC Auth Proxy

### DIFF
--- a/src/stac_auth_proxy/__init__.py
+++ b/src/stac_auth_proxy/__init__.py
@@ -7,7 +7,7 @@ with some internal STAC API.
 """
 
 from .app import configure_app, create_app
-from .config import Settings
+from .config import CoreSettings, ProxySettings, Settings
 from .lifespan import build_lifespan
 
 __all__ = [
@@ -15,4 +15,6 @@ __all__ = [
     "create_app",
     "configure_app",
     "Settings",
+    "ProxySettings",
+    "CoreSettings",
 ]

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -40,17 +40,14 @@ class _ClassInput(BaseModel):
         return cls(*self.args, **self.kwargs)
 
 
-class Settings(BaseSettings):
+class CoreSettings(BaseSettings):
     """Configuration settings for the STAC Auth Proxy."""
 
     # External URLs
-    upstream_url: HttpUrl
     oidc_discovery_url: HttpUrl
     oidc_discovery_internal_url: HttpUrl
     allowed_jwt_audiences: Optional[Sequence[str]] = None
 
-    root_path: str = ""
-    override_host: bool = True
     healthz_prefix: str = Field(pattern=_PREFIX_PATTERN, default="/healthz")
     wait_for_upstream: bool = True
     check_conformance: bool = True
@@ -112,3 +109,15 @@ class Settings(BaseSettings):
     def parse_audience(cls, v) -> Optional[Sequence[str]]:
         """Parse a comma separated string list of audiences into a list."""
         return str2list(v)
+
+
+class ProxySettings(CoreSettings):
+    """Configuration settings for the STAC Auth Proxy."""
+
+    # Proxy Configuration
+    upstream_url: HttpUrl
+    root_path: str = ""
+    override_host: bool = True
+
+
+Settings = ProxySettings


### PR DESCRIPTION
- Renamed `Settings` class to `CoreSettings` and created a new `ProxySettings` class that inherits from it.
- Updated imports in `__init__.py` to include `CoreSettings` and `ProxySettings`.
- Adjusted configuration structure to better organize settings related to proxy functionality.
