### PR TITLE
feat: Add forwarding of X-Forwarded-Port.

### DIFF
--- a/src/stac_auth_proxy/handlers/reverse_proxy.py
+++ b/src/stac_auth_proxy/handlers/reverse_proxy.py
@@ -45,6 +45,8 @@ class ReverseProxyHandler:
         proxy_proto = headers.get("X-Forwarded-Proto", request.url.scheme)
         proxy_host = headers.get("X-Forwarded-Host", request.url.netloc)
         proxy_path = headers.get("X-Forwarded-Path", request.base_url.path)
+        proxy_port = headers.get("X-Forwarded-Port")
+
         headers.setdefault(
             "Forwarded",
             f"for={proxy_client};host={proxy_host};proto={proxy_proto};path={proxy_path}",
@@ -56,6 +58,9 @@ class ReverseProxyHandler:
             headers.setdefault("X-Forwarded-Host", proxy_host)
             headers.setdefault("X-Forwarded-Path", proxy_path)
             headers.setdefault("X-Forwarded-Proto", proxy_proto)
+
+        if proxy_port:
+            headers["X-Forwarded-Port"] = proxy_port
 
         # Set host to the upstream host
         if self.override_host:


### PR DESCRIPTION
The HTTP X-Forwarded-Host (XFH) request header is an official but de-facto standard and not clearly defining when it comes to the way ports are indicated. It seems both of these approaches are common:

* `X-Forwarded-Host: example.com:80`
* `X-Forwarded-Host: example.com` with `X-Forwarded-Port: 80`

The second seems to be more common among ingress proxy solutions for kubernetes ([nginx](https://github.com/kubernetes/ingress-nginx/blob/d499ed9b8f9a132f62672031afee73ba95551113/rootfs/etc/nginx/template/nginx.tmpl#L1310) and [traefik](https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/headers/)).

The first approach with `X-Forwarded-Host: example.com:80` is already supported by _stac-auth-proxy_. This PR adds support for `X-Forwarded-Port` header. If _stac-auth-proxy_ receives it, to just forward it to the upstream STAC API.