### PR TITLE
Add record level auth

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
   stac-os:
     profiles: ["os"]
     container_name: stac-fastapi-os
-    image: ghcr.io/stac-utils/stac-fastapi-os:v6.1.0
+    image: ghcr.io/stac-utils/stac-fastapi-os:v6.7.6
     environment:
       STAC_FASTAPI_TITLE: stac-fastapi-opensearch + stac-auth-proxy
       STAC_FASTAPI_DESCRIPTION: A STAC FastAPI with an Opensearch backend, protected with STAC Auth Proxy
@@ -94,6 +94,15 @@ services:
       UPSTREAM_URL: ${UPSTREAM_URL:-http://stac:8001}
       OIDC_DISCOVERY_URL: ${OIDC_DISCOVERY_URL:-http://localhost:8888/.well-known/openid-configuration}
       OIDC_DISCOVERY_INTERNAL_URL: ${OIDC_DISCOVERY_INTERNAL_URL:-http://oidc:8888/.well-known/openid-configuration}
+      ITEMS_FILTER_CLS: stac_auth_proxy.filters.scope_based_item_filter:scope_based_filter
+      ITEMS_FILTER_ARGS: '["superuser"]'
+      OPENAPI_AUTH_SCHEME_NAME: jwtAuth
+      OPENAPI_AUTH_SCHEME_OVERRIDE: '{
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Paste your raw JWT here. This API uses Bearer token authorization."
+        }'
     env_file:
       - path: .env
         required: false

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -91,7 +91,7 @@ class Settings(BaseSettings):
 
     # Filters
     items_filter: Optional[_ClassInput] = None
-    items_filter_path: str = r"^(/collections/([^/]+)/items(/[^/]+)?$|/search$)"
+    items_filter_path: str = r"^(/collections/([^/]+)/items(/[^/]+)?$|/search$|/aggregate$)"
     collections_filter: Optional[_ClassInput] = None
     collections_filter_path: str = r"^/collections(/[^/]+)?$"
 

--- a/src/stac_auth_proxy/filters/scope_based_item_filter.py
+++ b/src/stac_auth_proxy/filters/scope_based_item_filter.py
@@ -1,0 +1,34 @@
+# my_filters.py
+"""CQL2 filter based on user scopes."""
+
+from typing import Any
+import logging
+
+logger = logging.getLogger(__name__)
+
+def scope_based_filter(superuser_role: str = "superuser"):
+    """
+    CQL2 builder that filters items based on user roles.
+    
+    - Users with superuser role see everything
+    - Other users only see items where _staging is omitted
+    
+    Args:
+        superuser_role: Role that grants full access
+    """
+    
+    async def filter_by_scope(ctx: dict[str, Any]) -> str:
+        """Generate CQL2 expression based on user scopes."""
+        payload = ctx.get("payload")
+        
+        if payload:
+            role_claim = payload.get("_roles", [])
+            roles = role_claim.split() if isinstance(role_claim, str) else role_claim or []
+            
+            if superuser_role in roles:
+                logger.info("Superuser request")
+                return None
+        
+        return "properties._staging IS NULL"
+    
+    return filter_by_scope

--- a/src/stac_auth_proxy/lifespan.py
+++ b/src/stac_auth_proxy/lifespan.py
@@ -30,9 +30,9 @@ async def check_server_healths(*urls: str | HttpUrl) -> None:
 
 async def check_server_health(
     url: str | HttpUrl,
-    max_retries: int = 10,
-    retry_delay: float = 1.0,
-    retry_delay_max: float = 5.0,
+    max_retries: int = 60,
+    retry_delay: float = 5.0,
+    retry_delay_max: float = 10.0,
     timeout: float = 5.0,
 ) -> None:
     """Wait for upstream API to become available."""

--- a/src/stac_auth_proxy/middleware/Cql2BuildFilterMiddleware.py
+++ b/src/stac_auth_proxy/middleware/Cql2BuildFilterMiddleware.py
@@ -88,6 +88,8 @@ class Cql2BuildFilterMiddleware:
                 **scope["state"],
             }
         )
+        if filter_expr is None:
+            return await self.app(scope, receive, send)
         cql2_filter = Expr(filter_expr)
         try:
             cql2_filter.validate()


### PR DESCRIPTION
This adds record-level auth based on the `superuser` role included in the JWT `_roles` claim.

If the JWT contains `_roles: ["superuser"]`, The stac-auth-proxy will leave the request as-is and return all available items

If not, the stac-auth-proxy will add a filter `"properties._staging IS NULL"` to the request. This will return items only where the `_staging` field is not included


Also increases the retry count and retry delay when pinging the upstream API health
