### PR TITLE
fix: Helm chart and app version mismatch.

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,4 +3,4 @@ name: stac-auth-proxy
 description: A Helm chart for stac-auth-proxy
 type: application
 version: 0.1.2
-appVersion: "1.0.0"
+appVersion: "0.11.0"


### PR DESCRIPTION
There seems to be a tiny mismatch between the app version specified in the helm chart (`1.0.0`) and the one of the application in `pyproject.toml` (`0.11.0`). Adjusting this.