### PR TITLE
chore: bump helm-chart version to 0.11.1.

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: stac-auth-proxy
 description: A Helm chart for stac-auth-proxy
 type: application
-version: 0.12.0
-appVersion: "0.12.0"
+version: 0.11.1
+appVersion: "0.11.1"


### PR DESCRIPTION
In preparation for the `0.12.0` release (https://github.com/developmentseed/stac-auth-proxy/pull/121).

I suggest we keep helm-chart and app version the same, to avoid confusion. But this is just a suggestion, happy to keep them separate if preferred.

