### PR TITLE
fix: stac-fastapi health checks.

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -134,7 +134,9 @@ The application is configurable via environment variables.
       "^/api$": ["GET"],
       "^/conformance$": ["GET"],
       "^/docs/oauth2-redirect": ["GET"],
-      "^/healthz": ["GET"]
+      "^/healthz": ["GET"],
+      "^/_mgmt/ping": ["GET"],
+      "^/_mgmt/health": ["GET"]
     }
     ```
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -95,7 +95,9 @@ env:
       "^/api.html$": ["GET"],
       "^/api$": ["GET"],
       "^/docs/oauth2-redirect": ["GET"],
-      "^/healthz": ["GET"]
+      "^/healthz": ["GET"],
+      "^/_mgmt/ping": ["GET"],
+      "^/_mgmt/health": ["GET"]
     }
 
 
@@ -110,4 +112,4 @@ serviceAccount:
   name: ""
   # Image pull secrets to add to the service account
   imagePullSecrets: []
-  # - name: my-registry-secret 
+  # - name: my-registry-secret

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -77,6 +77,8 @@ class Settings(BaseSettings):
         r"^/conformance$": ["GET"],
         r"^/docs/oauth2-redirect": ["GET"],
         r"^/healthz": ["GET"],
+        r"^/_mgmt/ping": ["GET"],
+        r"^/_mgmt/health": ["GET"],
     }
     private_endpoints: EndpointMethodsWithScope = {
         # https://github.com/stac-api-extensions/collection-transaction/blob/v1.0.0-beta.1/README.md#methods


### PR DESCRIPTION
`stac-fastapi` [provides](https://github.com/stac-utils/stac-fastapi/blob/main/stac_fastapi/api/stac_fastapi/api/app.py#L371) the following health check endpoints:

* `_mgmt/ping`
* `_mgmt/health`

This PR proposes to add those to the default public_endpoints.