### PR TITLE
feat: add extraContainers in helm-chart

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.sidecars }}
+      {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
 

--- a/helm/tests/deployment_test.yaml
+++ b/helm/tests/deployment_test.yaml
@@ -50,11 +50,11 @@ tests:
           path: spec.template.spec.containers[0].image
           value: "custom/repo:v1.2.3"
 
-  - it: should add sidecar containers
+  - it: should add extraContainer containers
     set:
       env.UPSTREAM_URL: "https://example.com"
       env.OIDC_DISCOVERY_URL: "https://example.com/.well-known/openid-configuration"
-      sidecars:
+      extraContainers:
         - name: oauth2-proxy
           image: quay.io/oauth2-proxy/oauth2-proxy:latest
           ports:
@@ -67,11 +67,31 @@ tests:
           path: spec.template.spec.containers[1].image
           value: quay.io/oauth2-proxy/oauth2-proxy:latest
 
-  - it: should not add sidecar containers when sidecars is empty
+  - it: should add multiple extraContainer containers
     set:
       env.UPSTREAM_URL: "https://example.com"
       env.OIDC_DISCOVERY_URL: "https://example.com/.well-known/openid-configuration"
-      sidecars: []
+      extraContainers:
+        - name: extraContainer-one
+          image: busybox:latest
+        - name: extraContainer-two
+          image: alpine:latest
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 3
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: extraContainer-one
+      - equal:
+          path: spec.template.spec.containers[2].name
+          value: extraContainer-two
+
+  - it: should not add extraContainer containers when extraContainers is empty
+    set:
+      env.UPSTREAM_URL: "https://example.com"
+      env.OIDC_DISCOVERY_URL: "https://example.com/.well-known/openid-configuration"
+      extraContainers: []
     asserts:
       - lengthEqual:
           path: spec.template.spec.containers

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -236,12 +236,12 @@ properties:
       additionalProperties: true
     description: "Init containers to run before the main container starts"
 
-  sidecars:
+  extraContainers:
     type: array
     items:
       type: object
       additionalProperties: true
-    description: "Sidecar containers to run alongside the main container"
+    description: "extraContainer containers to run alongside the main container"
 
   extraVolumes:
     type: array

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -71,10 +71,10 @@ extraVolumeMounts: []
 #     image: busybox:1.35
 #     command: ['sh', '-c', 'until nc -z oidc-server 8080; do sleep 2; done']
 
-# Sidecar containers to run alongside the main container
-sidecars: []
+# extraContainer containers to run alongside the main container
+extraContainers: []
 # Example:
-# sidecars:
+# extraContainers:
 #   - name: oauth2-proxy
 #     image: quay.io/oauth2-proxy/oauth2-proxy:latest
 #     ports:


### PR DESCRIPTION
As one of the features of the stac-auth-proxy is OPA integration and OPA can be launched as a sidecar, I added a sidecars section to the helm-chart so you can easily add OPA or other sidecars via the values file.


In the following example, I have added an OPA sidecar, as well as a busybox sidecar for checking the OPA API directly for debugging purposes.

```
env:
  UPSTREAM_URL: "https://example.stac.com/api/v1"
  OIDC_DISCOVERY_URL: "https://example.bouncer.com/.well-known/openid-configuration"
  COLLECTIONS_FILTER_CLS: "stac_auth_proxy.filters:Opa"
  COLLECTIONS_FILTER_ARGS: '["http://localhost:8181","stac/collections_cql2"]'
ingress:
  host: proxy.example.com
sidecars:
  - name: opa
    image: openpolicyagent/opa:1.13.1
    args:
    - "run"
    - "--server"
    - "--addr=:8181"
    - "--config-file=/run/secrets/opa-config.yaml"
    ports:
      - containerPort: 8181
    volumeMounts:
      - name: opa-config
        mountPath: /run/secrets
        readOnly: true
  - name: debug
    image: busybox:stable
    command: ["sleep", "infinity"]
extraVolumes:
  - name: opa-config
    secret:
      secretName: opa-config

```

edit: could also just be named extraContainers