### PR TITLE
ci: use pull_request_target to support PRs from forks

### DIFF
--- a/.github/workflows/conventional-commits-prs.yaml
+++ b/.github/workflows/conventional-commits-prs.yaml
@@ -1,7 +1,7 @@
 name: PR Conventional Commit Validation
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 jobs:


### PR DESCRIPTION
This fixes the 'Resource not accessible by integration' error that occurs when PRs come from forked repositories. 

`pull_request_target` runs in the context of the base repository, giving the action the necessary permissions to add labels to PRs from forks.