### PR TITLE
fix: ensure openapi spec demonstrates auth when cql2 filters apply

### DIFF
--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -108,6 +108,14 @@ def configure_app(
             root_path=settings.root_path,
             auth_scheme_name=settings.openapi_auth_scheme_name,
             auth_scheme_override=settings.openapi_auth_scheme_override,
+            items_filter_path=(
+                settings.items_filter_path if settings.items_filter else None
+            ),
+            collections_filter_path=(
+                settings.collections_filter_path
+                if settings.collections_filter
+                else None
+            ),
         )
 
     if settings.items_filter or settings.collections_filter:


### PR DESCRIPTION
Currently, the Swagger UI won't send auth credentials to endpoints if those endpoints are not marked as having a `security` scheme. While an endpoint may be public, the auth proxy might make use of those auth credentials to generate & apply CQL2 filters for row-level auth. As such, we should annotate an auth requirement to any endpoint that has CQL2 filters associated with it. It's important to note that these annotations do not actually denote an enforcement of auth, Swagger UI will still permit unauthenticated access. These annotations merely inform the Swagger UI client that auth credentials should be provided if possible.