### PR TITLE
fix: configurable upstream timeout.

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -12,6 +12,17 @@ The application is configurable via environment variables.
     - **Required:** Yes
     - **Example:** `https://your-stac-api.com/stac`
 
+### `UPSTREAM_TIMEOUT`
+
+: Timeout (in seconds) for requests forwarded to the upstream STAC API
+
+    - **Type:** float
+    - **Required:** No, defaults to `15.0`
+    - **Example:** `60.0`, `120`
+
+    > [!TIP]
+    > Increase this if your upstream API is slow to respond to expensive queries (e.g. large search results or heavy CQL2 filters) and you are seeing `500` errors caused by upstream timeouts.
+
 ### `WAIT_FOR_UPSTREAM`
 
 : Wait for upstream API to become available before starting proxy

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -35,6 +35,11 @@
           "pattern": "^https?://.+",
           "description": "URL of the STAC API to proxy"
         },
+        "UPSTREAM_TIMEOUT": {
+          "type": ["number", "string"],
+          "description": "Timeout in seconds for requests forwarded to the upstream STAC API",
+          "default": 15.0
+        },
         "WAIT_FOR_UPSTREAM": {
           "type": ["boolean", "string"],
           "description": "Wait for upstream API to become available before starting proxy",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -144,6 +144,7 @@ env:
   OIDC_DISCOVERY_URL: "http://localhost:8081/.well-known/openid-configuration"  # OpenID Connect discovery URL
 
   # Optional configuration
+  UPSTREAM_TIMEOUT: 15.0
   WAIT_FOR_UPSTREAM: true
   HEALTHZ_PREFIX: "/healthz"
   OIDC_DISCOVERY_INTERNAL_URL: "http://localhost:8081/.well-known/openid-configuration"

--- a/src/stac_auth_proxy/app.py
+++ b/src/stac_auth_proxy/app.py
@@ -8,6 +8,7 @@ authentication, authorization, and proxying of requests to some internal STAC AP
 import logging
 from typing import Any, Optional
 
+import httpx
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 from starlette_cramjam.middleware import CompressionMiddleware
@@ -235,6 +236,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
         ReverseProxyHandler(
             upstream=str(settings.upstream_url),
             override_host=settings.override_host,
+            timeout=httpx.Timeout(timeout=settings.upstream_timeout),
         ).proxy_request,
         methods=[
             "GET",

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -77,6 +77,7 @@ class Settings(BaseSettings):
     root_path: str = ""
     override_host: bool = True
     healthz_prefix: str = Field(pattern=_PREFIX_PATTERN, default="/healthz")
+    upstream_timeout: float = 15.0
     wait_for_upstream: bool = True
     check_conformance: bool = True
     enable_compression: bool = True


### PR DESCRIPTION
stac-auth-proxy has a hardcoded 15-second httpx timeout on upstream requests. This may cause 500 errors when a database takes longer to respond. But this can be desired. So this PR allows to make this timeout configurable.
