### PR TITLE
Fix/allow null filter expression

### DIFF
--- a/src/stac_auth_proxy/middleware/Cql2BuildFilterMiddleware.py
+++ b/src/stac_auth_proxy/middleware/Cql2BuildFilterMiddleware.py
@@ -92,6 +92,9 @@ class Cql2BuildFilterMiddleware:
                 **scope["state"],
             }
         )
+        if not filter_expr:
+            return await self.app(scope, receive, send)
+
         cql2_filter = Expr(filter_expr)
         try:
             cql2_filter.validate()

--- a/src/stac_auth_proxy/middleware/Cql2BuildFilterMiddleware.py
+++ b/src/stac_auth_proxy/middleware/Cql2BuildFilterMiddleware.py
@@ -107,7 +107,7 @@ class Cql2BuildFilterMiddleware:
 
     def _get_filter(
         self, path: str
-    ) -> Optional[Callable[..., Awaitable[str | dict[str, Any]]]]:
+    ) -> Optional[Callable[..., Awaitable[str | dict[str, Any] | None]]]:
         """Get the CQL2 filter builder for the given path."""
         endpoint_filters = [
             (self.collections_filter_path, self.collections_filter),

--- a/tests/test_cql2_build_filter_middleware.py
+++ b/tests/test_cql2_build_filter_middleware.py
@@ -89,3 +89,37 @@ class TestOptionsRequest:
         get_response = client.get("/collections/test-collection/items")
         assert get_response.status_code == 200
         assert get_response.json()["filter_was_built"] is True
+
+
+class TestEmptyFilter:
+    """Test middleware behavior with Empty Filter."""
+
+    def test_options_request_skips_filter_building(self):
+        """Test that OPTIONS requests skip CQL2 filter building."""
+        app = FastAPI()
+
+        # Create a simple filter that would be applied to items
+        async def items_filter(context):
+            return None
+
+        # Add middleware with a filter
+        app.add_middleware(
+            Cql2BuildFilterMiddleware,
+            items_filter=items_filter,
+        )
+
+        @app.get("/search")
+        async def search_get(request: Request):
+            # Check if the filter was built for comparison
+            cql2_filter = getattr(request.state, "cql2_filter", None)
+            return {
+                "filter_was_built": cql2_filter is not None,
+            }
+
+        client = TestClient(app)
+
+        # Test GET request - filter SHOULD be built
+        get_response = client.get("/search")
+        assert get_response.status_code == 200
+        get_data = get_response.json()
+        assert get_data["filter_was_built"] is False


### PR DESCRIPTION
this PR is on top of #179 

I think it's possible that a `filter_builder` to return `None`. In this case we need to return without adding a CQL2 filter 