### PR TITLE
fix: allow Any type for classInput

### DIFF
--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -28,8 +28,8 @@ class _ClassInput(BaseModel):
     """Input model for dynamically loading a class or function."""
 
     cls: str
-    args: Sequence[str] = Field(default_factory=list)
-    kwargs: dict[str, str] = Field(default_factory=dict)
+    args: Sequence[Any] = Field(default_factory=list)
+    kwargs: dict[str, Any] = Field(default_factory=dict)
 
     def __call__(self):
         """Dynamically load a class and instantiate it with args & kwargs."""


### PR DESCRIPTION
`Args` and `Kwargs` don't have to be of type `string` for the Class. Without this change, trying to pass something else than a string will raise a pydantic error 