### PR TITLE
fix: allow null healthz-prefix value

### DIFF
--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -76,7 +76,7 @@ class Settings(BaseSettings):
 
     root_path: str = ""
     override_host: bool = True
-    healthz_prefix: str = Field(pattern=_PREFIX_PATTERN, default="/healthz")
+    healthz_prefix: str | None = Field(pattern=_PREFIX_PATTERN, default="/healthz")
     upstream_timeout: float = 15.0
     wait_for_upstream: bool = True
     check_conformance: bool = True

--- a/tests/test_configure_app.py
+++ b/tests/test_configure_app.py
@@ -1,6 +1,8 @@
 """Tests for configuring an external FastAPI application."""
 
+import pytest
 from fastapi import APIRouter, FastAPI
+from pydantic import ValidationError
 
 from stac_auth_proxy import Settings, configure_app
 
@@ -65,3 +67,25 @@ def test_configure_app_excludes_proxy_route():
     routes = get_flattened_routes(app)
     assert settings.healthz_prefix in routes
     assert "/{path:path}" not in routes
+
+
+def test_configure_app_no_healthz():
+    """Ensure `configure_app` without adding health route."""
+    with pytest.raises(ValidationError):
+        settings = Settings(
+            upstream_url="https://example.com",
+            oidc_discovery_url="https://example.com/.well-known/openid-configuration",
+            healthz_prefix="",
+        )
+
+    app = FastAPI()
+    settings = Settings(
+        upstream_url="https://example.com",
+        oidc_discovery_url="https://example.com/.well-known/openid-configuration",
+        healthz_prefix=None,
+    )
+
+    configure_app(app, settings)
+
+    routes = get_flattened_routes(app)
+    assert settings.healthz_prefix not in routes


### PR DESCRIPTION
in `configure_app` there is a `if setting.healthz_prefix` check but in the current configuration, the `healthz_prefix` would always be set to a string matching `_PREFIX_PATTERN`. This PR makes `healthz_prefix` settings optional. 