### PR TITLE
ci: disable UV Cache for publishing workflows

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -18,7 +18,7 @@ jobs:
           python-version: ${{ env.LATEST_PY_VERSION }}
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
+          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/pre-commit
@@ -36,7 +36,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.9.*" 
-          enable-cache: true
+          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           python-version: ${{ matrix.python-version }}
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Set version from release tag
         if: github.event_name == 'release'
         run: |


### PR DESCRIPTION
This PR should fix some alerts raised by zizmor in https://github.com/developmentseed/stac-auth-proxy/pull/188