### PR TITLE
fix: allow , delimited string in configuration

### DIFF
--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -17,7 +17,7 @@ EndpointMethodsWithScope: TypeAlias = dict[
 _PREFIX_PATTERN = r"^/.*$"
 
 
-def str2list(x: str | Sequence[str]) -> Sequence[str] | str:
+def str2list(x: str | Sequence[str] | None) -> Sequence[str] | None:
     """Convert string to list based on , delimiter."""
     if isinstance(x, str):
         if x.startswith("["):

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -23,7 +23,7 @@ def str2list(x: str | Sequence[str]) -> Sequence[str] | str:
         if x.startswith("["):
             return json.loads(x)
         else:
-            return [s.strip() for s in x.split(",") if s.strip()]
+            return [s.strip() for s in x.split(",")]
 
     return x
 

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -145,6 +145,4 @@ class Settings(BaseSettings):
     @classmethod
     def parse_audience(cls, v) -> Sequence[str] | None:
         """Parse a comma separated string list of audiences into a list."""
-        if v:
-            return str2list(v)
-        return v
+        return str2list(v)

--- a/src/stac_auth_proxy/config.py
+++ b/src/stac_auth_proxy/config.py
@@ -1,6 +1,7 @@
 """Configuration for the STAC Auth Proxy."""
 
 import importlib
+import json
 from typing import Any, Literal, Optional, Sequence, TypeAlias, Union
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -16,12 +17,15 @@ EndpointMethodsWithScope: TypeAlias = dict[
 _PREFIX_PATTERN = r"^/.*$"
 
 
-def str2list(x: Optional[str] = None) -> Optional[Sequence[str]]:
+def str2list(x: str | Sequence[str]) -> Sequence[str] | str:
     """Convert string to list based on , delimiter."""
-    if x:
-        return x.replace(" ", "").split(",")
+    if isinstance(x, str):
+        if x.startswith("["):
+            return json.loads(x)
+        else:
+            return [s.strip() for s in x.split(",") if s.strip()]
 
-    return None
+    return x
 
 
 class _ClassInput(BaseModel):
@@ -58,7 +62,7 @@ class CorsSettings(BaseModel):
         mode="before",
     )
     @classmethod
-    def parse_list(cls, v):
+    def parse_list(cls, v) -> Sequence[str] | None:
         """Parse a comma-separated string into a list."""
         if isinstance(v, str):
             return [s.strip() for s in v.split(",") if s.strip()]
@@ -139,6 +143,8 @@ class Settings(BaseSettings):
 
     @field_validator("allowed_jwt_audiences", mode="before")
     @classmethod
-    def parse_audience(cls, v) -> Optional[Sequence[str]]:
+    def parse_audience(cls, v) -> Sequence[str] | None:
         """Parse a comma separated string list of audiences into a list."""
-        return str2list(v)
+        if v:
+            return str2list(v)
+        return v

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,97 @@
+"""Test config classes."""
+
+from stac_auth_proxy.config import CorsSettings, Settings
+
+
+def test_settings_model_config():
+    """Test that the model config is set correctly."""
+    settings = Settings(
+        upstream_url="https://example.com",
+        oidc_discovery_url="https://example.com/.well-known/openid-configuration",
+        oidc_discovery_internal_url="https://example2.com/.well-known/openid-configuration",
+    )
+    assert (
+        str(settings.oidc_discovery_internal_url)
+        == "https://example2.com/.well-known/openid-configuration"
+    )
+
+    settings = Settings(
+        upstream_url="https://example.com",
+        oidc_discovery_url="https://example.com/.well-known/openid-configuration",
+    )
+    assert (
+        str(settings.oidc_discovery_internal_url)
+        == "https://example.com/.well-known/openid-configuration"
+    )
+
+    settings = Settings(
+        upstream_url="https://example.com",
+        oidc_discovery_url="https://example.com/.well-known/openid-configuration",
+        allowed_jwt_audiences=["sfeos", "account"],
+    )
+    assert settings.allowed_jwt_audiences == ["sfeos", "account"]
+
+    settings = Settings(
+        upstream_url="https://example.com",
+        oidc_discovery_url="https://example.com/.well-known/openid-configuration",
+        allowed_jwt_audiences='["sfeos", "account"]',
+    )
+    assert settings.allowed_jwt_audiences == ["sfeos", "account"]
+
+    settings = Settings(
+        upstream_url="https://example.com",
+        oidc_discovery_url="https://example.com/.well-known/openid-configuration",
+        allowed_jwt_audiences="sfeos,account",
+    )
+    assert settings.allowed_jwt_audiences == ["sfeos", "account"]
+
+
+def test_settings_model_config_with_environment_variables(monkeypatch):
+    """Test that the model config is set correctly with environment variables."""
+    monkeypatch.setenv("UPSTREAM_URL", "https://example.com")
+    monkeypatch.setenv(
+        "OIDC_DISCOVERY_URL", "https://example.com/.well-known/openid-configuration"
+    )
+    monkeypatch.setenv("ALLOWED_JWT_AUDIENCES", "sfeos,account")
+
+    settings = Settings()
+    assert (
+        str(settings.oidc_discovery_internal_url)
+        == "https://example.com/.well-known/openid-configuration"
+    )
+    assert settings.allowed_jwt_audiences == ["sfeos", "account"]
+
+    monkeypatch.setenv("ALLOWED_JWT_AUDIENCES", '["user", "account"]')
+    settings = Settings()
+    assert (
+        str(settings.oidc_discovery_internal_url)
+        == "https://example.com/.well-known/openid-configuration"
+    )
+    assert settings.allowed_jwt_audiences == ["user", "account"]
+
+
+def test_cors_model_config():
+    """Test that the CORS model config is set correctly."""
+    cors_settings = CorsSettings(
+        allow_origins=["https://example.com", "https://example2.com"],
+        allow_methods=["GET", "POST"],
+        allow_headers=["Authorization", "Content-Type"],
+    )
+    assert cors_settings.allow_origins == [
+        "https://example.com",
+        "https://example2.com",
+    ]
+    assert cors_settings.allow_methods == ["GET", "POST"]
+    assert cors_settings.allow_headers == ["Authorization", "Content-Type"]
+
+    cors_settings = CorsSettings(
+        allow_origins="https://example.com,https://example2.com",
+        allow_methods="GET,POST",
+        allow_headers="Authorization,Content-Type",
+    )
+    assert cors_settings.allow_origins == [
+        "https://example.com",
+        "https://example2.com",
+    ]
+    assert cors_settings.allow_methods == ["GET", "POST"]
+    assert cors_settings.allow_headers == ["Authorization", "Content-Type"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,6 +45,13 @@ def test_settings_model_config():
     )
     assert settings.allowed_jwt_audiences == ["sfeos", "account"]
 
+    settings = Settings(
+        upstream_url="https://example.com",
+        oidc_discovery_url="https://example.com/.well-known/openid-configuration",
+        allowed_jwt_audiences="",
+    )
+    assert settings.allowed_jwt_audiences == [""]
+
 
 def test_settings_model_config_with_environment_variables(monkeypatch):
     """Test that the model config is set correctly with environment variables."""


### PR DESCRIPTION
closes #187 

This PR fixes #187 and also makes sure we can still use the regular *JSON* notation as well 

#### Take it of leave it

IMO, we should not have to support `,` delimited strings but let pydantic-settings do the parsing. Meaning that users would need to use `'["a","b"]'` notation instead of `"a,b"`. 

```python
import os 
from collections.abc import Sequence
from pydantic_settings import BaseSettings

class A(BaseSettings):

    value: Sequence[str]

A(value=["one", "two"])

os.environ["VALUE"] = "one,two"
A() # invalid

os.environ["VALUE"] = '["one","two"]'
A() # valid
```
