### PR TITLE
ci: add Claude auto PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   review:
-    uses: developmentseed/.github/.github/workflows/claude-pr-review.yml@main
+    uses: developmentseed/.github/.github/workflows/claude-pr-review.yml@cb3a57e9fe3f9c46ab2316a8f7b11fa752903131 # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -1,0 +1,16 @@
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    paths-ignore:
+      - '.github/workflows/**'
+
+jobs:
+  review:
+    uses: developmentseed/.github/.github/workflows/claude-pr-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    secrets: inherit

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -13,4 +13,5 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    secrets: inherit
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds the org-standard [Claude Auto Review](https://github.com/developmentseed/.github/blob/main/workflow-templates/claude-pr-review.yaml) caller workflow, which delegates to the reusable workflow in `developmentseed/.github`. Triggers on PR open/sync/reopen/ready-for-review and uses `secrets: inherit` for org-level auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)