### PR TITLE
fix(tests): fix flaky health-check retry test caused by global asyncio.sleep patch

### DIFF
--- a/src/stac_auth_proxy/lifespan.py
+++ b/src/stac_auth_proxy/lifespan.py
@@ -1,8 +1,8 @@
 """Reusable lifespan handler for FastAPI applications."""
 
-import asyncio
 import logging
 import re
+from asyncio import sleep
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -58,7 +58,7 @@ async def check_server_health(
                 f"Upstream API {url!r} not healthy, retrying in {retry_in:.1f}s "
                 f"(attempt {attempt + 1}/{max_retries})"
             )
-            await asyncio.sleep(retry_in)
+            await sleep(retry_in)
 
     raise RuntimeError(
         f"Upstream API {url!r} failed to respond after {max_retries} attempts"

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -30,7 +30,7 @@ async def test_check_server_health_success(source_api_server):
 async def test_check_server_health_failure():
     """Test health check failure."""
     with pytest.raises(RuntimeError) as exc_info:
-        with patch("asyncio.sleep") as mock_sleep:
+        with patch("stac_auth_proxy.lifespan.sleep") as mock_sleep:
             await check_server_health("http://localhost:9999")
     assert "failed to respond after" in str(exc_info.value)
     # Verify sleep was called with exponential backoff
@@ -50,7 +50,7 @@ async def test_check_server_health_retries_on_retryable_status(status_code):
     def handler(request):
         return httpx.Response(status_code)
 
-    with patch("asyncio.sleep") as mock_sleep:
+    with patch("stac_auth_proxy.lifespan.sleep") as mock_sleep:
         with patch(
             "httpx.AsyncClient",
             return_value=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
@@ -68,7 +68,7 @@ async def test_check_server_health_does_not_retry_on_non_retryable_status():
     def handler(request):
         return httpx.Response(404)
 
-    with patch("asyncio.sleep") as mock_sleep:
+    with patch("stac_auth_proxy.lifespan.sleep") as mock_sleep:
         with patch(
             "httpx.AsyncClient",
             return_value=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
@@ -92,7 +92,7 @@ async def test_check_server_health_recovers_from_retryable_status():
             return httpx.Response(503)
         return httpx.Response(200)
 
-    with patch("asyncio.sleep"):
+    with patch("stac_auth_proxy.lifespan.sleep"):
         with patch(
             "httpx.AsyncClient",
             return_value=httpx.AsyncClient(transport=httpx.MockTransport(handler)),


### PR DESCRIPTION
## Problem

`test_check_server_health_retries_on_retryable_status` fails intermittently in CI, appearing to be Python-version-specific (3.11 & 3.14) with `AssertionError: assert 1236 == 3`.

## Root cause

It's flaky, not version-specific. The test patches `asyncio.sleep` **process-wide**:

```python
with patch("asyncio.sleep") as mock_sleep:
    ...
assert mock_sleep.call_count == 3
```

The `source_api_server` fixture (`tests/conftest.py`) is **session-scoped** and runs `uvicorn.Server` in a background thread whose serve loop is `while not should_exit: await asyncio.sleep(0.1)`. Mocking `asyncio.sleep` globally removes that 0.1s throttle, turning the background loop into a busy-spin that racks up thousands of `sleep` calls in the fraction of a second the patch is active — inflating `mock_sleep.call_count` (e.g. to 1236).

Whether it fails depends on whether a `source_api_server`-using test already ran in the same xdist worker, which is nondeterministic. The "3.11/3.14 fail, 3.12/3.13 pass" pattern is coincidental timing/test-distribution, not a real interpreter difference.

## Fix

Import `sleep` into `lifespan.py` and patch `stac_auth_proxy.lifespan.sleep` instead of the global `asyncio.sleep`. This rebinds only the name in the module under test; the background uvicorn loop's `asyncio.sleep` stays real, so `call_count` reflects exactly the retries.

## Verification

- `ruff` + pre-commit hooks pass
- Full parallel suite (`pytest -n auto`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)