### PR TITLE
fix: normalize root_path_skip_prefixes in ProcessLinksMiddleware

### DIFF
--- a/src/stac_auth_proxy/middleware/ProcessLinksMiddleware.py
+++ b/src/stac_auth_proxy/middleware/ProcessLinksMiddleware.py
@@ -31,6 +31,14 @@ class ProcessLinksMiddleware(JsonResponseMiddleware):
     json_content_type_expr: str = r"application/(geo\+)?json"
     root_path_skip_prefixes: Sequence[str] = ()
 
+    def __post_init__(self) -> None:
+        """Normalize skip prefixes, dropping empty entries and trailing slashes."""
+        self.root_path_skip_prefixes = tuple(
+            prefix.rstrip("/")
+            for prefix in self.root_path_skip_prefixes
+            if prefix.rstrip("/")
+        )
+
     def should_transform_response(self, request: Request, scope: Scope) -> bool:
         """Only transform responses with JSON content type."""
         return bool(

--- a/tests/test_process_links.py
+++ b/tests/test_process_links.py
@@ -557,6 +557,18 @@ def test_transform_upstream_links_nested_objects():
                 "http://proxy.example.com/raster/tiles",
             ],
         ),
+        # Trailing slashes on directly-passed prefixes are normalized
+        (
+            ["/raster/"],
+            [
+                {"rel": "xyz", "href": "http://proxy.example.com/raster/tiles"},
+                {"rel": "exact", "href": "http://proxy.example.com/raster"},
+            ],
+            [
+                "http://proxy.example.com/raster/tiles",
+                "http://proxy.example.com/raster",
+            ],
+        ),
     ],
 )
 def test_transform_with_root_path_skip_prefixes(


### PR DESCRIPTION
Addressing edge case 1 in #200: If you pass a skip prefix with a trailing slash straight to the middleware (e.g. ["/raster/"]), it never matches any link. The skip list just stops working and links to sibling apps get ROOT_PATH added again (the issue #198 tried to prevent). Configuration via env vars is unaffected as the Settings validator normalizes the prefixes (strips trailing slashes, drops empties) before they reach the middleware, but not ProcessLinksMiddleware when it is constructed directly (prefixes passed directly to ProcessLinksMiddleware dont get such normalization)