### PR TITLE
fix: forward request headers when checking existing

### DIFF
--- a/src/stac_auth_proxy/middleware/Cql2ValidateTransactionMiddleware.py
+++ b/src/stac_auth_proxy/middleware/Cql2ValidateTransactionMiddleware.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import httpx
 from cql2 import Expr
+from starlette.datastructures import Headers
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -15,6 +16,15 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from ..utils.middleware import required_conformance
 
 logger = getLogger(__name__)
+
+# Hop-by-hop/body-sizing headers tied to the *original* (often bodied) request
+# that must not be copied onto the middleware's own bodyless upstream GET.
+_UNFORWARDED_HEADERS = {"host", "content-length", "content-type", "transfer-encoding"}
+
+
+def _forward_headers(headers: Headers) -> dict[str, str]:
+    """Select the subset of request headers safe to forward on internal requests."""
+    return {k: v for k, v in headers.items() if k.lower() not in _UNFORWARDED_HEADERS}
 
 
 def _deep_merge(base: dict, override: dict) -> dict:
@@ -74,11 +84,11 @@ class Cql2ValidateTransactionMiddleware:
                 return await self._handle_create(scope, receive, send, cql2_filter)
             if method in ("PUT", "PATCH"):
                 return await self._handle_update(
-                    scope, receive, send, cql2_filter, path, method
+                    scope, receive, send, cql2_filter, path, method, request.headers
                 )
             if method == "DELETE":
                 return await self._handle_delete(
-                    scope, receive, send, cql2_filter, path
+                    scope, receive, send, cql2_filter, path, request.headers
                 )
 
         # Match collections endpoints: /collections, /collections/{id}
@@ -87,11 +97,11 @@ class Cql2ValidateTransactionMiddleware:
                 return await self._handle_create(scope, receive, send, cql2_filter)
             if method in ("PUT", "PATCH"):
                 return await self._handle_update(
-                    scope, receive, send, cql2_filter, path, method
+                    scope, receive, send, cql2_filter, path, method, request.headers
                 )
             if method == "DELETE":
                 return await self._handle_delete(
-                    scope, receive, send, cql2_filter, path
+                    scope, receive, send, cql2_filter, path, request.headers
                 )
 
         # Not a transaction endpoint, pass through
@@ -120,9 +130,13 @@ class Cql2ValidateTransactionMiddleware:
 
         return new_receive
 
-    async def _fetch_existing(self, path: str) -> Optional[dict]:
+    async def _fetch_existing(
+        self, path: str, headers: Optional[Headers] = None
+    ) -> Optional[dict]:
         """Fetch the existing record from upstream."""
-        response = await self._client.get(path)
+        response = await self._client.get(
+            path, headers=_forward_headers(headers) if headers else None
+        )
         if response.status_code == 404:
             return None
         response.raise_for_status()
@@ -223,6 +237,7 @@ class Cql2ValidateTransactionMiddleware:
         cql2_filter: Expr,
         path: str,
         method: str,
+        headers: Headers,
     ) -> None:
         """Validate update requests."""
         body = await self._read_body(receive)
@@ -241,7 +256,7 @@ class Cql2ValidateTransactionMiddleware:
 
         # Fetch existing record
         try:
-            existing = await self._fetch_existing(path)
+            existing = await self._fetch_existing(path, headers)
         except httpx.HTTPError:
             response = JSONResponse(
                 {
@@ -295,10 +310,11 @@ class Cql2ValidateTransactionMiddleware:
         send: Send,
         cql2_filter: Expr,
         path: str,
+        headers: Headers,
     ) -> None:
         """Validate delete requests."""
         try:
-            existing = await self._fetch_existing(path)
+            existing = await self._fetch_existing(path, headers)
         except httpx.HTTPError:
             response = JSONResponse(
                 {

--- a/tests/test_cql2_validate_transaction_middleware.py
+++ b/tests/test_cql2_validate_transaction_middleware.py
@@ -7,11 +7,13 @@ import httpx
 import pytest
 from cql2 import Expr
 from fastapi import FastAPI, Request
+from starlette.datastructures import Headers
 from starlette.testclient import TestClient
 
 from stac_auth_proxy.middleware.Cql2ValidateTransactionMiddleware import (
     Cql2ValidateTransactionMiddleware,
     _deep_merge,
+    _forward_headers,
 )
 
 ITEM_FILTER = {"op": "=", "args": [{"property": "collection"}, "allowed"]}
@@ -141,6 +143,38 @@ class TestDeepMerge:
     def test_merge(self, base, override, expected):
         """Deep merge produces expected result."""
         assert _deep_merge(base, override) == expected
+
+
+class TestForwardHeaders:
+    """Test the _forward_headers helper."""
+
+    def test_keeps_auth_and_other_headers(self):
+        """Authorization and other non-excluded headers are kept."""
+        headers = Headers(
+            {
+                "authorization": "Bearer abc123",
+                "cookie": "session=xyz",
+                "accept": "application/json",
+            }
+        )
+        assert _forward_headers(headers) == {
+            "authorization": "Bearer abc123",
+            "cookie": "session=xyz",
+            "accept": "application/json",
+        }
+
+    def test_strips_hop_by_hop_and_sizing_headers(self):
+        """Host/content-length/content-type/transfer-encoding are stripped."""
+        headers = Headers(
+            {
+                "host": "proxy.example.com",
+                "content-length": "42",
+                "content-type": "application/json",
+                "transfer-encoding": "chunked",
+                "authorization": "Bearer abc123",
+            }
+        )
+        assert _forward_headers(headers) == {"authorization": "Bearer abc123"}
 
 
 class TestCreate:
@@ -490,6 +524,92 @@ class TestDelete:
         assert response.status_code == expected_status
         if error_code:
             assert response.json()["code"] == error_code
+
+
+class TestFetchExistingForwardsHeaders:
+    """
+    Regression test for the internal existing-record fetch dropping the
+    caller's Authorization header, which made PUT/PATCH/DELETE against a
+    private upstream endpoint fail upstream auth (401) and surface as a 502.
+    """
+
+    def _mock_client(self, handler):
+        return patch(
+            "httpx.AsyncClient",
+            return_value=httpx.AsyncClient(
+                base_url="http://upstream:8080",
+                transport=httpx.MockTransport(handler),
+            ),
+        )
+
+    def test_update_forwards_authorization(self, app_with_middleware, cql2_filter):
+        """PUT's internal existing-record fetch carries the caller's Authorization header."""
+        captured_headers = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(request.headers)
+            return httpx.Response(200, json={"id": "item1", "collection": "allowed"})
+
+        app = app_with_middleware()
+        _set_cql2_filter(app, cql2_filter)
+        client = TestClient(app)
+
+        with self._mock_client(handler):
+            response = client.put(
+                "/collections/allowed/items/item1",
+                json={"id": "item1", "collection": "allowed"},
+                headers={"Authorization": "Bearer token123"},
+            )
+
+        assert response.status_code == 200
+        assert captured_headers.get("authorization") == "Bearer token123"
+
+    def test_delete_forwards_authorization(self, app_with_middleware, cql2_filter):
+        """DELETE's internal existing-record fetch carries the caller's Authorization header."""
+        captured_headers = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(request.headers)
+            return httpx.Response(200, json={"id": "item1", "collection": "allowed"})
+
+        app = app_with_middleware()
+        _set_cql2_filter(app, cql2_filter)
+        client = TestClient(app)
+
+        with self._mock_client(handler):
+            response = client.delete(
+                "/collections/allowed/items/item1",
+                headers={"Authorization": "Bearer token123"},
+            )
+
+        assert response.status_code == 200
+        assert captured_headers.get("authorization") == "Bearer token123"
+
+    def test_does_not_forward_incoming_content_length(
+        self, app_with_middleware, cql2_filter
+    ):
+        """The bodied PUT's content-length must not leak onto the bodyless GET."""
+        captured_headers = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(request.headers)
+            return httpx.Response(200, json={"id": "item1", "collection": "allowed"})
+
+        app = app_with_middleware()
+        _set_cql2_filter(app, cql2_filter)
+        client = TestClient(app)
+
+        with self._mock_client(handler):
+            response = client.put(
+                "/collections/allowed/items/item1",
+                json={"id": "item1", "collection": "allowed", "extra": "x" * 100},
+                headers={"Authorization": "Bearer token123"},
+            )
+
+        assert response.status_code == 200
+        # A bodyless GET has no content-length; it must not be the original
+        # PUT body's content-length leaking through.
+        assert captured_headers.get("content-length") is None
 
 
 class TestPassthrough:


### PR DESCRIPTION
**disclaimer**: This PR was mostly done by Claude but I reviewed all the steps 

I hit an issue when trying to create/update/delete collections (using PUT requests) where I got 502 errors 👇   

> re-running ingest_data.py against an already-seeded database hits a 502 Bad Gateway on the PUT (update) fallback. That's in the external stac-auth-proxy dependency, not this repo — Cql2ValidateTransactionMiddleware._fetch_existing ([Cql2ValidateTransactionMiddleware.py:123-129](vscode-webview://0f26c55md1tls8logt363saaaufde4tvqju0lc9b424e3ke258gg/index.html?id=27ae0b20-94b5-4b57-b679-e33762cdbd5b&parentId=11&origin=4b672330-aa26-43fc-8d69-9f027cd01b5c&swVersion=5&extensionId=Anthropic.claude-code&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app&session=5981de4f-f3e5-484e-9cb0-be60f8297475)) does an internal GET to fetch the existing record for update-validation but never forwards the caller's Authorization header, so it 401s against a private endpoint and that gets mapped to a 502. Worth a heads-up since your ingest script is idempotent-by-design (POST-then-PUT-on-409) and will hit this on every re-run