### PR TITLE
feat: add HTTPException handling in CQL2BuildFilter middleware

### DIFF
--- a/src/stac_auth_proxy/middleware/Cql2BuildFilterMiddleware.py
+++ b/src/stac_auth_proxy/middleware/Cql2BuildFilterMiddleware.py
@@ -6,8 +6,9 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional
 
 from cql2 import Expr, ValidationError
+from fastapi import HTTPException
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from ..utils import requests
@@ -80,24 +81,31 @@ class Cql2BuildFilterMiddleware:
         if not filter_builder:
             return await self.app(scope, receive, send)
 
-        filter_expr = await filter_builder(
-            {
-                "req": {
-                    "path": request.url.path,
-                    "method": request.method,
-                    "query_params": dict(request.query_params),
-                    "path_params": requests.extract_variables(request.url.path),
-                    "headers": dict(request.headers),
-                },
-                **scope["state"],
-            }
-        )
+        try:
+            filter_expr = await filter_builder(
+                {
+                    "req": {
+                        "path": request.url.path,
+                        "method": request.method,
+                        "query_params": dict(request.query_params),
+                        "path_params": requests.extract_variables(request.url.path),
+                        "headers": dict(request.headers),
+                    },
+                    **scope["state"],
+                }
+            )
+        except HTTPException as e:
+            response = JSONResponse({"detail": e.detail}, status_code=e.status_code)
+            return await response(scope, receive, send)
+
         cql2_filter = Expr(filter_expr)
         try:
             cql2_filter.validate()
         except ValidationError:
             logger.error("Invalid CQL2 filter: %s", filter_expr)
-            return Response(status_code=502, content="Invalid CQL2 filter")
+            response = JSONResponse({"detail": "Invalid CQL2 filter"}, status_code=502)
+            return await response(scope, receive, send)
+
         setattr(request.state, self.state_key, cql2_filter)
 
         return await self.app(scope, receive, send)

--- a/tests/test_cql2_build_filter_middleware.py
+++ b/tests/test_cql2_build_filter_middleware.py
@@ -1,6 +1,6 @@
 """Test Cql2BuildFilterMiddleware."""
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from starlette.testclient import TestClient
 
 from stac_auth_proxy.middleware.Cql2BuildFilterMiddleware import (
@@ -89,3 +89,39 @@ class TestOptionsRequest:
         get_response = client.get("/collections/test-collection/items")
         assert get_response.status_code == 200
         assert get_response.json()["filter_was_built"] is True
+
+
+class TestErrorHandling:
+    """Test middleware behavior when filter_fcn returns an exception."""
+
+    def test_exception_handling(self):
+        """Test that the middleware correctly handles exceptions raised by the filter function."""
+        app = FastAPI()
+
+        # Create a simple filter, function raise an exception if user is not "good"
+        async def items_filter(context):
+            query_params = context["req"].get("query_params", {})
+            if query_params.get("user") != "good":
+                raise HTTPException(status_code=403, detail="Bad user")
+
+            return "private = false"
+
+        # Add middleware with a filter
+        app.add_middleware(
+            Cql2BuildFilterMiddleware,
+            items_filter=items_filter,
+        )
+
+        @app.get("/search")
+        async def search_get(request: Request):
+            return {}
+
+        client = TestClient(app)
+
+        # Test GET request SHOULD return 403 for bad user
+        get_response = client.get("/search")
+        assert get_response.status_code == 403
+
+        # Test GET request SHOULD return 200 for good user
+        get_response = client.get("/search", params={"user": "good"})
+        assert get_response.status_code == 200


### PR DESCRIPTION
When building the CQL2 filter, users can raise exception that will be handled as 500 error by the application. 

This PR tries to solve this by adding a try/catch block, to catch any HTTPException and return a correct response. 