### PR TITLE
fix: allow queryables endpoints for collections

### DIFF
--- a/src/stac_auth_proxy/utils/requests.py
+++ b/src/stac_auth_proxy/utils/requests.py
@@ -20,8 +20,8 @@ def extract_variables(url: str) -> dict:
     we can't rely on the path parameters that FastAPI provides.
     """
     path = urlparse(url).path
-    # This allows either /items or /bulk_items, with an optional item_id following.
-    pattern = r"^/collections/(?P<collection_id>[^/]+)(?:/(?:items|bulk_items)(?:/(?P<item_id>[^/]+))?)?/?$"
+    # This allows either /queryables or /items or /bulk_items, with an optional item_id following.
+    pattern = r"^/collections/(?P<collection_id>[^/]+)(?:/(?:items|bulk_items|queryables)(?:/(?P<item_id>[^/]+))?)?/?$"
     match = re.match(pattern, path)
     return {k: v for k, v in match.groupdict().items() if v} if match else {}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ from stac_auth_proxy.utils.requests import (
     (
         ("/collections/123", {"collection_id": "123"}),
         ("/collections/123/items", {"collection_id": "123"}),
+        ("/collections/123/queryables", {"collection_id": "123"}),
         ("/collections/123/bulk_items", {"collection_id": "123"}),
         ("/collections/123/items/456", {"collection_id": "123", "item_id": "456"}),
         ("/collections/123/bulk_items/456", {"collection_id": "123", "item_id": "456"}),


### PR DESCRIPTION
in my application, I have `/collections/{collectionId}/queryables` endpoints available but I want to make sure all `/collections/{collectionId}/...` endpoints are going through my opa filter, and for which I need to extract the path-parameter.

It worked well for all my endpoints, except for the `.../queryables` endpoint because it was missing in the `request.extract_variables` method 