### PR TITLE
fix: allow text in json response for CQl2RewriteLinksFilterMiddleware

### DIFF
--- a/src/stac_auth_proxy/middleware/Cql2RewriteLinksFilterMiddleware.py
+++ b/src/stac_auth_proxy/middleware/Cql2RewriteLinksFilterMiddleware.py
@@ -124,35 +124,36 @@ class Cql2RewriteLinksFilterMiddleware:
             await send({"type": "http.response.body", "body": body, "more_body": False})
             return
 
-        links = data.get("links")
-        if isinstance(links, list):
-            for link in links:
-                # Handle filter in query string
-                if "href" in link:
-                    url = urlparse(link["href"])
-                    qs = parse_qs(url.query)
-                    if "filter" in qs:
-                        if user_filter is not None:
-                            qs["filter"] = [user_filter.to_text()]
-                        else:
-                            qs.pop("filter", None)
-                            qs.pop("filter-lang", None)
-                        new_query = urlencode(qs, doseq=True)
-                        link["href"] = urlunparse(url._replace(query=new_query))
-
-                # Handle filter in body (for POST links). The spec only
-                # requires cql2-json for POST bodies, but if the link advertises
-                # cql2-text we preserve that lang on the way out.
-                if "body" in link and isinstance(link["body"], dict):
-                    if "filter" in link["body"]:
-                        if user_filter is not None:
-                            if link["body"].get("filter-lang") == "cql2-text":
-                                link["body"]["filter"] = user_filter.to_text()
+        if isinstance(data, dict):
+            links = data.get("links")
+            if isinstance(links, list):
+                for link in links:
+                    # Handle filter in query string
+                    if "href" in link:
+                        url = urlparse(link["href"])
+                        qs = parse_qs(url.query)
+                        if "filter" in qs:
+                            if user_filter is not None:
+                                qs["filter"] = [user_filter.to_text()]
                             else:
-                                link["body"]["filter"] = user_filter.to_json()
-                        else:
-                            link["body"].pop("filter", None)
-                            link["body"].pop("filter-lang", None)
+                                qs.pop("filter", None)
+                                qs.pop("filter-lang", None)
+                            new_query = urlencode(qs, doseq=True)
+                            link["href"] = urlunparse(url._replace(query=new_query))
+
+                    # Handle filter in body (for POST links). The spec only
+                    # requires cql2-json for POST bodies, but if the link advertises
+                    # cql2-text we preserve that lang on the way out.
+                    if "body" in link and isinstance(link["body"], dict):
+                        if "filter" in link["body"]:
+                            if user_filter is not None:
+                                if link["body"].get("filter-lang") == "cql2-text":
+                                    link["body"]["filter"] = user_filter.to_text()
+                                else:
+                                    link["body"]["filter"] = user_filter.to_json()
+                            else:
+                                link["body"].pop("filter", None)
+                                link["body"].pop("filter-lang", None)
 
         # Send the modified response
         new_body = json.dumps(data).encode("utf-8")

--- a/tests/test_cql2_rewrite_links_filter_middleware.py
+++ b/tests/test_cql2_rewrite_links_filter_middleware.py
@@ -93,6 +93,25 @@ class TestEdgeCases:
         data = response.json()
         assert data == {"links": "not a list"}
 
+    def test_text_in_json(self):
+        """Test text encoded as JSON."""
+        app = FastAPI()
+        app.add_middleware(Cql2RewriteLinksFilterMiddleware)
+
+        @app.get("/plain")
+        async def plain():
+            return Response(content="not json", media_type="text/plain")
+
+        @app.get("/text", response_model=str)
+        async def plain_text():
+            return "text in json"
+
+        client = TestClient(app)
+        response = client.get("/text")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/json"
+        assert response.text == '"text in json"'
+
 
 class TestMiddlewareStackSimulation:
     """Test middleware behavior by simulating the full middleware stack."""


### PR DESCRIPTION
I've hit an issue with the `bulk_items` endpoints and the CQL2 middleware.

The bulk_endpoint will return a JSON response but with simple text. This is pretty weird and I've raised an issue upstream:  https://github.com/stac-utils/stac-fastapi/issues/971